### PR TITLE
Packer and Terraform templates for Dogwood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ vagrant_ansible_inventory_default
 playbooks/appsemblerPlaybooks/inventory.ini
 playbooks/appsemblerPlaybooks/db-vars.yml
 playbooks/appsemblerPlaybooks/server-vars.yml
+server-vars.yml

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ playbooks/appsemblerPlaybooks/inventory.ini
 playbooks/appsemblerPlaybooks/db-vars.yml
 playbooks/appsemblerPlaybooks/server-vars.yml
 terraform/*.tfstate*
+gcloud-account.json
 server-vars.yml

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ vagrant_ansible_inventory_default
 playbooks/appsemblerPlaybooks/inventory.ini
 playbooks/appsemblerPlaybooks/db-vars.yml
 playbooks/appsemblerPlaybooks/server-vars.yml
+terraform/*.tfstate*
 server-vars.yml

--- a/packer/dogwood-base-gce-local.json
+++ b/packer/dogwood-base-gce-local.json
@@ -1,0 +1,43 @@
+{
+  "description": "Dogwood.3 edX image for GCE",
+  "builders": [{
+    "type": "googlecompute",
+    "account_file": "../gcloud-account.json",
+    "project_id": "appsembler-testing",
+    "source_image": "ubuntu-1204-precise-v20160516",
+    "zone": "us-east1-b",
+    "disk_size": 50,
+    "image_name": "dogwood-packer-local"
+  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "sudo apt-get update -y",
+        "sudo apt-get install -y build-essential software-properties-common python-software-properties curl git-core libxml2-dev libxslt1-dev libfreetype6-dev python-pip python-apt python-dev libxmlsec1-dev swig libmysqlclient-dev",
+        "sudo pip install --upgrade pip",
+        "sudo pip install --upgrade virtualenv",
+        "cd /tmp",
+        "git clone https://github.com/appsembler/configuration.git --branch appsembler/release --depth 1",
+        "cd configuration",
+        "sudo pip install -r requirements.txt",
+        "sudo pip install setuptools --upgrade"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "../server-vars.yml",
+      "destination": "/tmp/server-vars.yml"
+    },
+    {
+      "type": "ansible-local",
+      "playbook_file": "../playbooks/edx_sandbox.yml",
+      "playbook_dir": "../playbooks",
+      "extra_arguments": [ "--extra-vars", "@/tmp/server-vars.yml" ]
+    },
+    {
+      "type": "shell",
+      "inline": "rm /tmp/server-vars.yml"
+    }
+  ]
+}

--- a/packer/dogwood-base-gce-remote.json
+++ b/packer/dogwood-base-gce-remote.json
@@ -1,0 +1,25 @@
+{
+  "description": "Dogwood.3 edX image for GCE",
+  "builders": [{
+    "type": "googlecompute",
+    "account_file": "../gcloud-account.json",
+    "project_id": "appsembler-testing",
+    "source_image": "ubuntu-1204-precise-v20160516",
+    "zone": "us-east1-b",
+    "disk_size": 50,
+    "image_name": "dogwood3-packer-remote"
+  }],
+  "provisioners": [
+    {
+      "type": "ansible",
+      "playbook_file": "../playbooks/edx_sandbox.yml",
+      "command": "/Users/bezidejni/.pyenv/versions/edx_configuration/bin/ansible-playbook",
+      "extra_arguments": [ "--extra-vars", "@../server-vars.yml" ],
+      "ansible_env_vars": [
+        "ANSIBLE_HOST_KEY_CHECKING=False",
+        "ANSIBLE_JINJA2_EXTENSIONS=jinja2.ext.do",
+        "ANSIBLE_ROLES_PATH='../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/'"
+      ]
+    }
+  ]
+}

--- a/terraform/gcloud.tf
+++ b/terraform/gcloud.tf
@@ -1,0 +1,39 @@
+provider "google" {
+    credentials = "${file("gcloud-account.json")}"
+    project = "appsembler-testing"
+    region = "us-east1-b"
+}
+
+resource "google_compute_firewall" "default" {
+  name = "dogwood-terraform-firewall"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports = ["80"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags = ["web"]
+}
+
+resource "google_compute_instance" "default" {
+    name = "dogwood-terraform-test"
+    machine_type = "n1-standard-1"
+    zone = "us-east1-b"
+    tags = ["web"]
+
+    network_interface {
+      network = "default"
+      access_config {
+        // Ephemeral IP
+      }
+    }
+
+    disk {
+      image = "dogwood-packer-local"
+      type = "pd-standard"
+      size = 50
+    }
+
+}


### PR DESCRIPTION
Added two simple packer templates for building a base Dogwood edX image on Google Cloud, one using [ansible local](https://www.packer.io/docs/provisioners/ansible-local.html) provisioner, other using [ansible remote](https://www.packer.io/docs/provisioners/ansible.html) provisioner. Ansible local is way way faster for now.

Also added a Terraform template that creates a new VM instance with the image generated from packer.

**This is a WIP so please don't merge yet!**

You'll need a `gcloud-account.json` file in the repo root, downloaded from Google Cloud as per instructions [here](https://www.packer.io/docs/builders/googlecompute.html) under "Running Without A Compute Engine Service Account". Also, for generating images, you'll also need `server-vars.yml` in the repo root, I used [this one](https://github.com/noderabbit-team/edx-configs/blob/master/baseSettings/files/dogwood-gcloud-server-vars.yml) for testing.

Planned work:

- [ ] add packer template for generating a custom image for customers, based on the base image using a customized `server-vars.yml` file
- [ ] more configurable Terraform template