### PR TITLE
Add stackdriver role

### DIFF
--- a/playbooks/roles/stackdriver/defaults/main.yml
+++ b/playbooks/roles/stackdriver/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+stackdriver_distro_codename: "precise"
+stackdriver_repo_url: "http://repo.stackdriver.com/apt"
+stackdriver_pubkey_url: "https://app.stackdriver.com/RPM-GPG-KEY-stackdriver"
+stackdriver_api_key: ""
+stackdriver_detect_gcm: "yes"

--- a/playbooks/roles/stackdriver/handlers/main.yml
+++ b/playbooks/roles/stackdriver/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart stackdriver
+  service: name=stackdriver-agent state=restarted

--- a/playbooks/roles/stackdriver/tasks/main.yml
+++ b/playbooks/roles/stackdriver/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Add Stackdriver public key
+  apt_key: url={{ stackdriver_pubkey_url }} state=present
+  tags: ['stackdriver', 'stackdriver:install']
+
+- name: Add Stackdriver repository
+  apt_repository: >
+    repo="deb {{ stackdriver_repo_url }} {{ stackdriver_distro_codename }} main"
+    update_cache=yes
+  tags: ['stackdriver', 'stackdriver:install']
+
+- name: Install Stackdriver agent
+  apt: name=stackdriver-agent
+  tags: ['stackdriver', 'stackdriver:install']
+
+- name: Copy Stackdriver configuration
+  template: src=stackdriver-agent dest=/etc/default/stackdriver-agent
+  notify: restart stackdriver
+  tags: ['stackdriver', 'stackdriver:configuration']

--- a/playbooks/roles/stackdriver/templates/stackdriver-agent
+++ b/playbooks/roles/stackdriver/templates/stackdriver-agent
@@ -1,0 +1,10 @@
+# whether or not to autogenerate the stackdriver collectd config file
+AUTOGENERATE_COLLECTD_CONFIG="yes"
+
+# url to a proxy for outbound https
+PROXY_URL=""
+
+# stackdriver api key
+STACKDRIVER_API_KEY="{{ stackdriver_api_key }}"
+
+DETECT_GCM="{{ stackdriver_detect_gcm }}"


### PR DESCRIPTION
This role installs and configures the Stackdriver agent. If deployed on GCP, setting `stackdriver_detect_gcm: "yes"` (which is default) should allow the agent to talk to Google Cloud Monitoring without further configuration. Otherwise, the `stackdriver_api_key` (found in the Stackdriver account settings) can be specified.