### PR TITLE
Add mysql_init role

### DIFF
--- a/playbooks/mysql_init.yml
+++ b/playbooks/mysql_init.yml
@@ -1,0 +1,22 @@
+---
+
+# This play should run locally and target a remote MySQL instance by setting
+# mysql_login_user, mysql_login_password, mysql_login_host, and
+# mysql_login_port
+- name: Configure mysql DBs and users
+  hosts: all
+  sudo: False
+  gather_facts: False
+  vars_files:
+    - roles/analytics_api/defaults/main.yml
+    - roles/analytics_pipeline/defaults/main.yml
+    - roles/common_vars/defaults/main.yml
+    - roles/ecommerce/defaults/main.yml
+    - roles/edxapp/defaults/main.yml
+    - roles/edx_notes_api/defaults/main.yml
+    - roles/hive/defaults/main.yml
+    - roles/insights/defaults/main.yml
+    - roles/programs/defaults/main.yml
+    - roles/xqueue/defaults/main.yml
+  roles:
+    - mysql_init

--- a/playbooks/roles/mysql_init/defaults/main.yml
+++ b/playbooks/roles/mysql_init/defaults/main.yml
@@ -1,0 +1,60 @@
+---
+
+mysql_login_user: "root"
+mysql_login_password: "password"
+mysql_login_host: "localhost"
+mysql_login_port: 3306
+mysql_user_host: "localhost"
+
+mysql_databases:
+  - "{{ ECOMMERCE_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ INSIGHTS_DATABASE_NAME | default(None) }}"
+  - "{{ ORA_MYSQL_DB_NAME | default(None) }}"
+  - "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}"
+  - "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}"
+  - "{{ EDX_NOTES_API_MYSQL_DB_NAME | default(None) }}"
+  - "{{ PROGRAMS_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ ANALYTICS_API_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ ANALYTICS_API_REPORTS_DB_NAME | default(None) }}"
+
+mysql_database_users:
+  - {
+      db: "{{ ECOMMERCE_DEFAULT_DB_NAME | default(None) }}",
+      user: "{{ ECOMMERCE_DATABASES.default.USER | default(None) }}",
+      pass: "{{ ECOMMERCE_DATABASES.default.PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ INSIGHTS_DATABASE_NAME | default(None) }}",
+      user: "{{ INSIGHTS_DATABASES.default.USER | default(None) }}",
+      pass: "{{ INSIGHTS_DATABASES.default.PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ ORA_MYSQL_DB_NAME | default(None) }}",
+      user: "{{ ORA_MYSQL_USER | default(None) }}",
+      pass: "{{ ORA_MYSQL_PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}",
+      user: "{{ XQUEUE_MYSQL_USER | default(None) }}",
+      pass: "{{ XQUEUE_MYSQL_PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}",
+      user: "{{ EDXAPP_MYSQL_USER | default(None) }}",
+      pass: "{{ EDXAPP_MYSQL_PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ PROGRAMS_DEFAULT_DB_NAME | default(None) }}",
+      user: "{{ PROGRAMS_DATABASES.default.USER | default(None) }}",
+      pass: "{{ PROGRAMS_DATABASES.default.PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE_NAME | default(None) }}",
+      user: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.username }}",
+      pass: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.password }}"
+    }
+  - {
+      db: "{{ HIVE_METASTORE_DATABASE_NAME | default(None) }}",
+      user: "{{ HIVE_METASTORE_DATABASE.user | default(None) }}",
+      pass: "{{ HIVE_METASTORE_DATABASE.password | default(None) }}"
+    }

--- a/playbooks/roles/mysql_init/tasks/main.yml
+++ b/playbooks/roles/mysql_init/tasks/main.yml
@@ -1,0 +1,110 @@
+---
+
+- name: create databases
+  mysql_db:
+    db: "{{ item }}"
+    state: present
+    encoding: utf8
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: item != None and item != ''
+  with_items: "{{ mysql_databases }}"
+
+- name: create database users
+  mysql_user:
+    name: "{{ item.user }}"
+    password: "{{ item.pass }}"
+    priv: "{{ item.db }}.*:ALL"
+    append_privs: yes
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: item.db != None and item.db != ''
+  with_items: "{{ mysql_database_users }}"
+
+- name: setup the migration db user
+  mysql_user:
+    name: "{{ COMMON_MYSQL_MIGRATE_USER }}"
+    password: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
+    priv: "{{ item }}.*:ALL"
+    append_privs: yes
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: item != None and item != ''
+  with_items: "{{ mysql_databases }}"
+
+- name: create api user for the analytics api
+  mysql_user:
+    name: "api001"
+    password: "{{ ANALYTICS_API_DATABASES.default.PASSWORD }}"
+    priv: '{{ ANALYTICS_API_DATABASES.default.NAME }}.*:ALL/reports.*:SELECT'
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: ANALYTICS_API_SERVICE_CONFIG is defined
+
+- name: create read-only reports user for the analytics-api
+  mysql_user:
+    name: reports001
+    password: "{{ ANALYTICS_API_DATABASES.reports.PASSWORD }}"
+    priv: '{{ ANALYTICS_API_DATABASES.reports.NAME }}.*:SELECT'
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: ANALYTICS_API_SERVICE_CONFIG is defined
+
+- name: create a database for the hive metastore
+  mysql_db:
+    db: "{{ HIVE_METASTORE_DATABASE.name }}"
+    state: "present"
+    encoding: "latin1"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: HIVE_METASTORE_DATABASE is defined
+
+- name: setup the edx-notes-api db user
+  mysql_user:
+    name: "{{ EDX_NOTES_API_MYSQL_DB_USER }}"
+    password: "{{ EDX_NOTES_API_MYSQL_DB_PASS }}"
+    priv: "{{ EDX_NOTES_API_MYSQL_DB_NAME }}.*:SELECT,INSERT,UPDATE,DELETE"
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+  when: EDX_NOTES_API_MYSQL_DB_USER is defined
+
+- name: setup the read-only db user
+  mysql_user:
+    name: "{{ COMMON_MYSQL_READ_ONLY_USER }}"
+    password: "{{ COMMON_MYSQL_READ_ONLY_PASS }}"
+    priv: "*.*:SELECT"
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"
+
+- name: setup the admin db user
+  mysql_user:
+    name: "{{ COMMON_MYSQL_ADMIN_USER }}"
+    password: "{{ COMMON_MYSQL_ADMIN_PASS }}"
+    priv: "*.*:CREATE USER"
+    host: "{{ mysql_user_host }}"
+    login_user: "{{ mysql_login_user }}"
+    login_password: "{{ mysql_login_password }}"
+    login_host: "{{ mysql_login_host }}"
+    login_port: "{{ mysql_login_port }}"


### PR DESCRIPTION
This role configures a remote MySQL instances, such as Google Cloud SQL. It creates the same users and tables as the [edxlocal](https://github.com/appsembler/configuration/tree/appsembler/master/playbooks/roles/edxlocal) role, but additional parameters are added to each task to specify the database host and login credentials.

To configure a remote MySQL instance, the `mysql_init.yml` playbook can be run locally:

```
ansible-playbook -i localhost, -c local mysql_init.yml -e @my-vars.yml
```