### PR TITLE
Use multipart uploads for backups to S3

### DIFF
--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -20,6 +20,11 @@
   when: BACKUPS_PROVIDER == 'gs'
   tags: ['backups']
 
+- name: Install filechunkio for multipart S3 uploads
+  pip: name=filechunkio state=present
+  when: BACKUPS_PROVIDER == 's3'
+  tags: ['backups']
+
 - name: Copy boto configuration
   template: src=boto.j2 dest="{{ BACKUPS_GS_BOTO_FILE }}" owner=root group=root mode=0600
   when: BACKUPS_PROVIDER == 'gs'


### PR DESCRIPTION
The maximum file size for a single-PUT upload is 5GB. We now break files into 100MB chunks and perform a multipart upload. The chunks are reassembled by S3 into a single file once the upload completes. See [Storing Large Data](https://boto.readthedocs.io/en/latest/s3_tut.html#storing-large-data).