### PR TITLE
Refactors testdrive vs. amc stuff and merges into appsembler/master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,11 @@ vagrant_ansible_inventory_default
 :2e_*
 :2e#
 
-#appsembler specific
+### Appsembler specific
 playbooks/appsemblerPlaybooks/inventory.ini
 playbooks/appsemblerPlaybooks/db-vars.yml
 playbooks/appsemblerPlaybooks/server-vars.yml
-.python-version
 playbooks/roles/nginx/templates/edx/app/nginx/sites-available/extra_locations*
 playbooks/roles/nginx/templates/edx/app/nginx/sites-available/extra_http*
 playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files-extra.j2
+

--- a/docker/build/course_discovery/Dockerfile
+++ b/docker/build/course_discovery/Dockerfile
@@ -1,0 +1,29 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/course_discovery/Dockerfile .
+#
+# This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
+# with the currently checked-out configuration repo.
+
+FROM edxops/trusty-common
+MAINTAINER edxops
+
+ARG COURSE_DISCOVERY_VERSION=master
+ARG REPO_OWNER=edx
+
+ADD . /edx/app/edx_ansible/edx_ansible
+
+USER docker
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+COPY docker/build/course_discovery/ansible_overrides.yml /
+RUN sudo ansible-playbook course_discovery.yml -c local \
+    -t 'install:base,install:code,install:system-requirements,install:app-requirements,install:configuration,install:vhosts,install:devstack' \
+    --extra-vars="@/ansible_overrides.yml" \
+    --extra-vars="COURSE_DISCOVERY_VERSION=$COURSE_DISCOVERY_VERSION" \
+    --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
+
+USER root 
+CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]

--- a/docker/build/course_discovery/ansible_overrides.yml
+++ b/docker/build/course_discovery/ansible_overrides.yml
@@ -1,0 +1,2 @@
+---
+course_discovery_gunicorn_host: 0.0.0.0

--- a/docker/build/course_discovery/inventory
+++ b/docker/build/course_discovery/inventory
@@ -1,0 +1,2 @@
+[local]
+localhost

--- a/playbooks/Makefile
+++ b/playbooks/Makefile
@@ -1,6 +1,8 @@
-.PHONY = monitoring
+.PHONY = monitoring deploy-testdrive mysql-init-testdrive mongo-replicaset-testdrive
 
 .DEFAULT_GOAL = help
+
+EDXCONFIGS_BRANCH=master
 
 ## Install monitoring on customer cluster. Example: CUSTOMER=qa ENVIRONMENT=production TIER=basic PLATFORM=azure make monitoring
 monitoring:
@@ -9,6 +11,32 @@ monitoring:
 	@@if test -z "$$TIER"; then echo "ERROR: TIER is not defined."; exit 1; fi;
 	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@ansible-playbook -i inventory monitoring.yml --extra-vars "@../../edx-configs/$$CUSTOMER/$$ENVIRONMENT/server-vars.yml"
+
+## Deploy testdrive
+deploy-testdrive:
+	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@appsembler/scripts/check_git_is_up2date.sh
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory testdrive.yml --ask-vault-pass
+
+## Run mysql_init.yml playbook for testdrive
+mysql-init-testdrive:
+	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@appsembler/scripts/check_git_is_up2date.sh
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory mysql_init.yml \
+		--ask-vault-pass \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/files/vault/secrets.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/files/server-vars.yml" \
+		--limit mysql_init
+
+## Run mongo_replicasets.yml playbook for testdrive
+mongo-replicaset-testdrive:
+	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@appsembler/scripts/check_git_is_up2date.sh
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory mongo_replicaset.yml \
+		--ask-vault-pass \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/files/vault/secrets.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/files/server-vars.yml" \
+		--limit mongo
 
 ## Show help screen.
 help:

--- a/playbooks/Makefile
+++ b/playbooks/Makefile
@@ -12,36 +12,43 @@ monitoring:
 	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@ansible-playbook -i inventory monitoring.yml --extra-vars "@../../edx-configs/$$CUSTOMER/$$ENVIRONMENT/server-vars.yml"
 
-## Deploy testdrive
+## Deploy testdrive. Needs ENVIRONMENT defined. For example. ENVIRONEMT=production make deploy-testdrive
 deploy-testdrive:
 	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@appsembler/scripts/check_git_is_up2date.sh
-	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory testdrive.yml --ask-vault-pass
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/hosts/inventory testdrive.yml --ask-vault-pass \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/vault/secrets.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/server-vars.yml"
 
-## Deploy AMC
+## Deploy AMC. Needs ENVIRONMENT defined. For example. ENVIRONEMT=production make deploy-amc
 deploy-amc:
 	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@appsembler/scripts/check_git_is_up2date.sh
-	@ansible-playbook --inventory-file=../../edx-configs/appsembler/amc/hosts/inventory amc.yml
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/amc/$$ENVIRONMENT/hosts/inventory amc.yml \
+		--extra-vars "@../../edx-configs/appsembler/amc/$$ENVIRONMENT/files/server-vars.yml"
 
-## Run mysql_init.yml playbook for testdrive
+## Run mysql_init.yml playbook for testdrive. Needs ENVIRONMENT defined. For example. ENVIRONEMT=production make mysql-init-testdrive
 mysql-init-testdrive:
 	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@appsembler/scripts/check_git_is_up2date.sh
-	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory mysql_init.yml \
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/hosts/inventory mysql_init.yml \
 		--ask-vault-pass \
-		--extra-vars "@../../edx-configs/appsembler/testdrive/files/vault/secrets.yml" \
-		--extra-vars "@../../edx-configs/appsembler/testdrive/files/server-vars.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/vault/secrets.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/server-vars.yml" \
 		--limit mysql_init
 
-## Run mongo_replicasets.yml playbook for testdrive
+## Run mongo_replicasets.yml playbook for testdrive. Needs ENVIRONMENT defined. For example. ENVIRONEMT=production make mongo-replicaset-testdrive
 mongo-replicaset-testdrive:
 	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@@if test -z "$$ENVIRONMENT"; then echo "ERROR: ENVIRONMENT is not defined."; exit 1; fi;
 	@appsembler/scripts/check_git_is_up2date.sh
-	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory mongo_replicaset.yml \
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/hosts/inventory mongo_replicaset.yml \
 		--ask-vault-pass \
-		--extra-vars "@../../edx-configs/appsembler/testdrive/files/vault/secrets.yml" \
-		--extra-vars "@../../edx-configs/appsembler/testdrive/files/server-vars.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/vault/secrets.yml" \
+		--extra-vars "@../../edx-configs/appsembler/testdrive/$$ENVIRONMENT/files/server-vars.yml" \
 		--limit mongo
 
 ## Show help screen.

--- a/playbooks/Makefile
+++ b/playbooks/Makefile
@@ -1,4 +1,4 @@
-.PHONY = monitoring deploy-testdrive mysql-init-testdrive mongo-replicaset-testdrive
+.PHONY = monitoring deploy-testdrive mysql-init-testdrive mongo-replicaset-testdrive deploy-amc
 
 .DEFAULT_GOAL = help
 
@@ -17,6 +17,12 @@ deploy-testdrive:
 	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
 	@appsembler/scripts/check_git_is_up2date.sh
 	@ansible-playbook --inventory-file=../../edx-configs/appsembler/testdrive/hosts/inventory testdrive.yml --ask-vault-pass
+
+## Deploy AMC
+deploy-amc:
+	$(eval EDXCONFIGS_REPO_LOCAL_BRANCH := $(shell cd ../../edx-configs && git symbolic-ref --short -q HEAD))
+	@appsembler/scripts/check_git_is_up2date.sh
+	@ansible-playbook --inventory-file=../../edx-configs/appsembler/amc/hosts/inventory amc.yml
 
 ## Run mysql_init.yml playbook for testdrive
 mysql-init-testdrive:

--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -13,8 +13,6 @@
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
-  vars_files:
-    - ../../edx-configs/appsembler/amc/files/server-vars.yml
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: nginx

--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -1,0 +1,57 @@
+---
+
+- name: Configure instance(s)
+  hosts: edx
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    openid_workaround: True
+    EDXAPP_LMS_NGINX_PORT: '80'
+    # Set to false if deployed behind another proxy/load balancer.
+    NGINX_SET_X_FORWARDED_HEADERS: True
+    # These should stay false for the public AMI
+    COMMON_ENABLE_DATADOG: False
+    COMMON_ENABLE_SPLUNKFORWARDER: False
+  vars_files:
+    - ../../edx-configs/appsembler/amc/files/server-vars.yml
+  roles:
+    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+    - role: nginx
+      nginx_sites:
+      - certs
+      - cms
+      - lms
+      - forum
+      - xqueue
+      nginx_default_sites:
+      - lms
+    - role: mysql
+      when: EDXAPP_MYSQL_HOST == 'localhost'
+    - edxlocal
+    - role: mongo
+      when: "'localhost' in EDXAPP_MONGO_HOSTS"
+    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
+    - { role: 'edxapp', celery_worker: True }
+    - edxapp
+    - notifier
+    - analytics_api
+    - insights
+    - edx_notes_api
+    - demo
+    - oauth_client_setup
+    - oraclejdk
+    - role: elasticsearch
+      when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"
+    - forum
+    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
+    - { role: "xqueue", update_users: True }
+    - certs
+    - edx_ansible
+    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+    - role: datadog
+      when: COMMON_ENABLE_DATADOG
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC

--- a/playbooks/appsembler/scripts/check_git_is_up2date.sh
+++ b/playbooks/appsembler/scripts/check_git_is_up2date.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+CONFIGS_LOCAL=$(cd ../../edx-configs && git rev-parse @)
+CONFIGS_REMOTE=$(cd ../../edx-configs && git rev-parse @{u})
+
+echo "Checking if edx-configs repo is up2date."
+if [ $CONFIGS_LOCAL = $CONFIGS_REMOTE ]; then
+    echo "edx-configs repo is Up-to-date."
+else
+    echo "edx-configs repo branch is not up2date."
+    exit 1;
+fi
+
+# Check to see if there are any local changes on the edx-configs local branch
+if [ -n "$(cd ../../edx-configs && git status --porcelain)" ]; then
+  echo "ERROR: You have local uncommited changes in your local edx-configs branch.";
+  exit 1;
+fi
+

--- a/playbooks/mongo_replicaset.yml
+++ b/playbooks/mongo_replicaset.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Configure instance(s)
+  hosts: mongo
+  sudo: True
+  gather_facts: True
+  roles:
+    - mongo_3_0
+

--- a/playbooks/mysql_init.yml
+++ b/playbooks/mysql_init.yml
@@ -20,3 +20,4 @@
     - roles/xqueue/defaults/main.yml
   roles:
     - mysql_init
+

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -144,7 +144,7 @@
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
     DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
-    EDX_PLATFORM_SETTINGS_OVERRIDE: "aws_migrate"
+    EDX_PLATFORM_SETTINGS_OVERRIDE: "devstack_appsembler"
   with_items: service_variants_enabled
   tags:
     - migrate

--- a/playbooks/roles/mongo_3_0/templates/repset_add_secondaries.js.j2
+++ b/playbooks/roles/mongo_3_0/templates/repset_add_secondaries.js.j2
@@ -29,7 +29,7 @@ if(!rs.status().ok) { throw 'Mongo Cluster Not Ok';}
 // Check that the cluster has the right number of members
 // and add them if we are the master
 if(rs.isMaster().ismaster) {
-    if(rs.status().members.length!={{ hosts|length }}) {
+    if(rs.status().members.length!={{ hosts|list|length }}) {
         {% for host in hosts %}
           {%- if host != ansible_default_ipv4["address"] -%}
             rs.add({_id: {{ loop.index }}, host: '{{ host }}'});
@@ -38,7 +38,7 @@ if(rs.isMaster().ismaster) {
         sleep(30000);
         // Check status and member account, throw exception if not
         if(!rs.status().ok) { throw 'Mongo Cluster Not Ok';}
-        if(rs.status().members.length!={{ hosts|length }}) {
+        if(rs.status().members.length!={{ hosts|list|length }}) {
             throw 'Could not add all members to cluster'
         }
     }

--- a/playbooks/roles/mysql_init/defaults/main.yml
+++ b/playbooks/roles/mysql_init/defaults/main.yml
@@ -5,7 +5,6 @@ mysql_login_password: "password"
 mysql_login_host: "localhost"
 mysql_login_port: 3306
 mysql_user_host: "localhost"
-
 mysql_databases:
   - "{{ ECOMMERCE_DEFAULT_DB_NAME | default(None) }}"
   - "{{ INSIGHTS_DATABASE_NAME | default(None) }}"

--- a/playbooks/roles/mysql_init/tasks/main.yml
+++ b/playbooks/roles/mysql_init/tasks/main.yml
@@ -108,3 +108,4 @@
     login_password: "{{ mysql_login_password }}"
     login_host: "{{ mysql_login_host }}"
     login_port: "{{ mysql_login_port }}"
+

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -1,3 +1,9 @@
+{% if "insights" in nginx_default_sites %}
+  {% set default_site = "default" %}
+{% else %}
+  {% set default_site = "" %}
+{% endif %}
+
 upstream insights_app_server {
     {% for host in nginx_insights_gunicorn_hosts %}
         server {{ host }}:{{ insights_gunicorn_port }} fail_timeout=0;
@@ -5,7 +11,8 @@ upstream insights_app_server {
 }
 
 server {
-  listen {{ INSIGHTS_NGINX_PORT }} default_server;
+  listen {{ INSIGHTS_NGINX_PORT }} {{ default_site }};
+  server_name {{ INSIGHTS_HOSTNAME }};
 
   location ~ ^/static/(?P<file>.*) {
     root {{ COMMON_DATA_DIR }}/{{ insights_service_name }};
@@ -32,17 +39,17 @@ location @proxy_to_app {
     proxy_redirect off;
     proxy_pass http://insights_app_server;
   }
-  
+
   {% if NGINX_REDIRECT_TO_HTTPS %}
   # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
+  if ($scheme != "https")
+  {
    set $do_redirect_to_https "true";
   }
 
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
+  # Nginx does not support nested conditions
+  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB
+  if ($http_x_forwarded_proto = "http")
   {
    set $do_redirect_to_https "true";
   }

--- a/playbooks/roles/oauth_client_setup/tasks/main.yml
+++ b/playbooks/roles/oauth_client_setup/tasks/main.yml
@@ -10,20 +10,20 @@
 #
 #
 # Tasks for role oauth_client_setup
-# 
+#
 # Overview:
-# 
+#
 #
 # Dependencies:
 #
-# 
+#
 # Example play:
 #
 #
 
 - name: create OAuth2 Clients
   shell: >
-    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings=aws
+    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings=devstack_appsembler
     create_oauth2_client
     {{ item.url_root }}
     "{{ item.url_root }}/complete/edx-oidc/"

--- a/playbooks/roles/scorm/tasks/main.yml
+++ b/playbooks/roles/scorm/tasks/main.yml
@@ -1,9 +1,12 @@
-# CONFIGURE NGINX 
+# CONFIGURE NGINX
 # SYNC LOCAL SCORM CONTENT PACKAGES WITH S3 IF NOT STORED THERE TO BEGIN WITH
 
-- include_vars: "/edx/app/edx_ansible/edx_ansible/playbooks/roles/common_vars/defaults/main.yml"
-- include_vars: "/edx/app/edx_ansible/edx_ansible/playbooks/roles/edxapp/defaults/main.yml"
-- include_vars: "/edx/app/edx_ansible/edx_ansible/playbooks/roles/edx_ansible/defaults/main.yml"
+- include_vars: "roles/common_vars/defaults/main.yml"
+- include_vars: "roles/edxapp/defaults/main.yml"
+- include_vars: "roles/edx_ansible/defaults/main.yml"
+
+# - name: debug for edxapp include_vars
+#   debug: var=edxapp_use_custom_theme
 
 - name: create all service directories
   file: >
@@ -27,11 +30,12 @@
 
 
 ## check out any custom player repos
-- debug: 
+<<<<<<< HEAD
+- debug:
     msg: "{{ EDXAPP_AUTH_EXTRA.SCORMPLAYER_GIT_IDENTITIES[item] }}"
   with_items: EDXAPP_XBLOCK_SETTINGS.ScormXBlock.SCORM_PLAYER_BACKENDS.keys()
 
-- name: install read-only ssh key for the scormplayer repo(s)   
+- name: install read-only ssh key for the scormplayer repo(s)
   copy: >
     content="{{ EDXAPP_AUTH_EXTRA.SCORMPLAYER_GIT_IDENTITIES[item] }}" dest=/tmp/scormplayer_{{ item }}_identity
     force=yes owner={{ scorm_player_dir.owner }} mode=0600
@@ -58,9 +62,9 @@
   apt: >
     pkg=sharutils
     state=present
-    update_cache=yes  
+    update_cache=yes
   when: SCORM_S3_BACKUP
-  
+
 - name: create s3 config for SCORM backup
   template: >
     dest={{ scorm_dirs.home.path }}/.s3cfg
@@ -98,7 +102,8 @@
     owner=edx-ansible
     group=edx-ansible
     mode=0644
-  with_items: 
+  with_items:
    - extra_locations_lms.j2
    - static-files-extra.j2
   when: EDXAPP_XBLOCK_SETTINGS.ScormXBlock
+

--- a/playbooks/roles/server_utils/meta/main.yml
+++ b/playbooks/roles/server_utils/meta/main.yml
@@ -10,7 +10,7 @@
 ##
 # Role includes for role insights
 # 
-dependencies:
-  - common
+# dependencies:
+#   - common
 
 

--- a/playbooks/testdrive.yml
+++ b/playbooks/testdrive.yml
@@ -13,9 +13,6 @@
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
-  vars_files:
-    - ../../edx-configs/appsembler/testdrive/files/vault/secrets.yml
-    - ../../edx-configs/appsembler/testdrive/files/server-vars.yml
   tasks:
     - name: install memcached
       apt: pkg=memcached state=present

--- a/playbooks/testdrive.yml
+++ b/playbooks/testdrive.yml
@@ -1,23 +1,24 @@
 ---
 
-# Example sandbox configuration
-# for single server community
-# installs
-
 - name: Configure instance(s)
-  hosts: all
+  hosts: edx
   sudo: True
   gather_facts: True
   vars:
     migrate_db: "yes"
     openid_workaround: True
     EDXAPP_LMS_NGINX_PORT: '80'
-    edx_platform_version: 'master'
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
+  vars_files:
+    - ../../edx-configs/appsembler/testdrive/files/vault/secrets.yml
+    - ../../edx-configs/appsembler/testdrive/files/server-vars.yml
+  tasks:
+    - name: install memcached
+      apt: pkg=memcached state=present
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: scorm
@@ -29,22 +30,27 @@
       - lms
       - forum
       - xqueue
+      - edx_notes_api
+      - insights
       nginx_default_sites:
       - lms
-    - role: mysql
-      when: EDXAPP_MYSQL_HOST == 'localhost'
-    - edxlocal
-    - role: mongo
-      when: "'localhost' in EDXAPP_MONGO_HOSTS"
-    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - notifier
     - analytics_api
-    - edx_notes_api
+    - analytics_pipeline
     - insights
+    - edx_notes_api
     - demo
+    - {
+        role: 'demo',
+        demo_code_dir: "{{ demo_app_dir }}/test101",
+        demo_repo: "https://github.com/cptvitamin/demo-test-course",
+        demo_course_id: "course-v1:edX+Test101+course",
+        tags: 'demo_test101',
+      }
     - oauth_client_setup
+    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - oraclejdk
     - role: elasticsearch
       when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -368,8 +368,8 @@ fi
 
 extra_args_opts+=" -e@$extra_vars"
 
-ansible-playbook -vvvv -c local -i "localhost," $play.yml $extra_args_opts
-ansible-playbook -vvvv -c local -i "localhost," stop_all_edx_services.yml $extra_args_opts
+ansible-playbook -vvvv -c local -i "localhost," --skip-tags="install:devstack,migrate:devstack" $play.yml $extra_args_opts
+ansible-playbook -vvvv -c local -i "localhost," --skip-tags="install:devstack,migrate:devstack" stop_all_edx_services.yml $extra_args_opts
 
 rm -rf $base_dir
 

--- a/vagrant/release/devstack/Vagrantfile.amc
+++ b/vagrant/release/devstack/Vagrantfile.amc
@@ -1,0 +1,164 @@
+Vagrant.require_version ">= 1.6.5"
+unless Vagrant.has_plugin?("vagrant-vbguest")
+  raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
+end
+
+VAGRANTFILE_API_VERSION = "2"
+
+MEMORY = 4096
+CPU_COUNT = 2
+
+$script = <<SCRIPT
+if [ ! -d /edx/app/edx_ansible ]; then
+    echo "Error: Base box is missing provisioning scripts." 1>&2
+    exit 1
+fi
+OPENEDX_RELEASE=$1
+export PYTHONUNBUFFERED=1
+source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
+cd /edx/app/edx_ansible/edx_ansible/playbooks
+
+OPENEDX_RELEASE="named-release/dogwood.3"
+APPSEMBLER_VARS="-e edx_platform_repo="https://github.com/appsembler/edx-platform.git" \
+  -e edx_platform_version="appsembler/amc/develop" \
+  -e edx_ansible_source_repo="https://github.com/appsembler/configuration.git" \
+  -e configuration_version="appsembler/amc/develop"
+  -e certs_version=$OPENEDX_RELEASE \
+  -e forum_version=$OPENEDX_RELEASE \
+  -e xqueue_version=$OPENEDX_RELEASE \
+"
+ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible $APPSEMBLER_VARS
+ansible-playbook -i localhost, -c local vagrant-devstack.yml $APPSEMBLER_VARS
+
+SCRIPT
+
+MOUNT_DIRS = {
+  :edx_platform => {:repo => "edx-platform", :local => "/edx/app/edxapp/edx-platform", :owner => "edxapp"},
+  :themes => {:repo => "themes", :local => "/edx/app/edxapp/themes", :owner => "edxapp"},
+  :forum => {:repo => "cs_comments_service", :local => "/edx/app/forum/cs_comments_service", :owner => "forum"},
+  :ecommerce => {:repo => "ecommerce", :local => "/edx/app/ecommerce/ecommerce", :owner => "ecommerce"},
+  :ecommerce_worker => {:repo => "ecommerce-worker", :local => "/edx/app/ecommerce_worker/ecommerce_worker", :owner => "ecommerce_worker"},
+  :programs => {:repo => "programs", :local => "/edx/app/programs/programs", :owner => "programs"},
+  # This src directory won't have useful permissions. You can set them from the
+  # vagrant user in the guest OS. "sudo chmod 0777 /edx/src" is useful.
+  :src => {:repo => "src", :local => "/edx/src", :owner => "root"},
+
+}
+if ENV['VAGRANT_MOUNT_BASE']
+  MOUNT_DIRS.each { |k, v| MOUNT_DIRS[k][:repo] = ENV['VAGRANT_MOUNT_BASE'] + "/" + MOUNT_DIRS[k][:repo] }
+end
+
+# map the name of the git branch that we use for a release
+# to a name and a file path, which are used for retrieving
+# a Vagrant box from the internet.
+openedx_releases = {
+  # Note: the devstack and fullstack boxes differ, because devstack had an issue
+  # that needed fixing, but it didn't affect fullstack.
+  "named-release/dogwood.rc" => {
+    :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
+  },
+  "named-release/dogwood.1" => {
+    :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
+  },
+  "named-release/dogwood.2" => {
+    :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
+  },
+  "named-release/dogwood.3" => {
+    :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
+  },
+  "named-release/dogwood" => {
+    :name => "dogwood-devstack-rc2", :file => "20151221-dogwood-devstack-rc2.box",
+  },
+  # Cypress is deprecated and unsupported
+  # "named-release/cypress" => {
+  #   :name => "cypress-devstack", :file => "cypress-devstack.box",
+  # },
+  # Birch is deprecated and unsupported
+  # "named-release/birch.2" => {
+  #   :name => "birch-devstack-2", :file => "birch-2-devstack.box",
+  # },
+}
+openedx_releases.default = {
+  :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
+}
+openedx_releases_vmware = {
+  "named-release/birch" => {
+    :name => "birch-devstack-vmware", :file => "20150610-birch-devstack-vmware.box",
+  },
+}
+openedx_releases_vmware.default = {
+  :name => "kifli-devstack-vmware", :file => "20140829-kifli-devstack-vmware.box",
+}
+rel = ENV['OPENEDX_RELEASE']
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Creates an edX devstack VM from an official release
+  config.vm.box     = openedx_releases[rel][:name]
+  config.vm.box_url = "http://files.edx.org/vagrant-images/#{openedx_releases[rel][:file]}"
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+
+  # If you want to run the box but don't need network ports, set VAGRANT_NO_PORTS=1.
+  # This is useful if you want to run more than one box at once.
+  if not ENV['VAGRANT_NO_PORTS']
+    config.vm.network :forwarded_port, guest: 8000, host: 8000  # LMS
+    config.vm.network :forwarded_port, guest: 8001, host: 8001  # Studio
+    config.vm.network :forwarded_port, guest: 8002, host: 8002  # Ecommerce
+    config.vm.network :forwarded_port, guest: 8003, host: 8003  # LMS for Bok Choy
+    config.vm.network :forwarded_port, guest: 8031, host: 8031  # Studio for Bok Choy
+    config.vm.network :forwarded_port, guest: 8120, host: 8120  # edX Notes Service
+    config.vm.network :forwarded_port, guest: 8765, host: 8765
+    config.vm.network :forwarded_port, guest: 9200, host: 9200  # Elasticsearch
+    config.vm.network :forwarded_port, guest: 18080, host: 18080  # Forums
+    config.vm.network :forwarded_port, guest: 8100, host: 8100  # Analytics Data API
+    config.vm.network :forwarded_port, guest: 8110, host: 8110  # Insights
+    config.vm.network :forwarded_port, guest: 9876, host: 9876  # ORA2 Karma tests
+    config.vm.network :forwarded_port, guest: 50070, host: 50070  # HDFS Admin UI
+    config.vm.network :forwarded_port, guest: 8088, host: 8088  # Hadoop Resource Manager
+  end
+  config.ssh.insert_key = true
+
+  config.vm.synced_folder  ".", "/vagrant", disabled: true
+
+  # Enable X11 forwarding so we can interact with GUI applications
+  if ENV['VAGRANT_X11']
+    config.ssh.forward_x11 = true
+  end
+
+  if ENV['VAGRANT_USE_VBOXFS'] == 'true'
+    MOUNT_DIRS.each { |k, v|
+      config.vm.synced_folder v[:repo], v[:local], create: true, owner: v[:owner], group: "www-data"
+    }
+  else
+    MOUNT_DIRS.each { |k, v|
+      config.vm.synced_folder v[:repo], v[:local], create: true, nfs: true
+    }
+  end
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
+    vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
+
+    # Allow DNS to work for Ubuntu 12.10 host
+    # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      override.vm.box     = openedx_releases_vmware[rel][:name]
+      override.vm.box_url = "http://files.edx.org/vagrant-images/#{openedx_releases_vmware[rel][:file]}"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
+
+  # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
+  config.vbguest.auto_reboot = true
+  config.vbguest.auto_update = true
+
+  # Assume that the base box has the edx_ansible role installed
+  # We can then tell the Vagrant instance to update itself.
+  config.vm.provision "shell", inline: $script, args: rel
+end

--- a/vagrant/release/devstack/Vagrantfile.amc
+++ b/vagrant/release/devstack/Vagrantfile.amc
@@ -18,17 +18,35 @@ export PYTHONUNBUFFERED=1
 source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 cd /edx/app/edx_ansible/edx_ansible/playbooks
 
-OPENEDX_RELEASE="named-release/dogwood.3"
+# Did we specify an openedx release?
+if [ -n "$OPENEDX_RELEASE" ]; then
+  EXTRA_VARS="-e edx_platform_version=$OPENEDX_RELEASE \
+    -e certs_version=$OPENEDX_RELEASE \
+    -e forum_version=$OPENEDX_RELEASE \
+    -e xqueue_version=$OPENEDX_RELEASE \
+    -e demo_version=$OPENEDX_RELEASE \
+    -e NOTIFIER_VERSION=$OPENEDX_RELEASE \
+    -e ECOMMERCE_VERSION=$OPENEDX_RELEASE \
+    -e ECOMMERCE_WORKER_VERSION=$OPENEDX_RELEASE \
+    -e PROGRAMS_VERSION=$OPENEDX_RELEASE \
+  "
+  CONFIG_VER=$OPENEDX_RELEASE
+  # Need to ensure that the configuration repo is updated
+  # The vagrant-devstack.yml playbook will also do this, but only
+  # after loading the playbooks into memory.  If these are out of date,
+  # this can cause problems (e.g. looking for templates that no longer exist).
+  /edx/bin/update configuration $CONFIG_VER
+else
+  CONFIG_VER="master"
+fi
+
 APPSEMBLER_VARS="-e edx_platform_repo="https://github.com/appsembler/edx-platform.git" \
   -e edx_platform_version="appsembler/amc/develop" \
   -e edx_ansible_source_repo="https://github.com/appsembler/configuration.git" \
-  -e configuration_version="appsembler/amc/develop"
-  -e certs_version=$OPENEDX_RELEASE \
-  -e forum_version=$OPENEDX_RELEASE \
-  -e xqueue_version=$OPENEDX_RELEASE \
 "
-ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible $APPSEMBLER_VARS
-ansible-playbook -i localhost, -c local vagrant-devstack.yml $APPSEMBLER_VARS
+
+ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS $APPSEMBLER_VARS
+ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS $APPSEMBLER_VARS
 
 SCRIPT
 
@@ -52,6 +70,18 @@ end
 # to a name and a file path, which are used for retrieving
 # a Vagrant box from the internet.
 openedx_releases = {
+  "open-release/eucalyptus.master" => {
+    :name => "eucalyptus-devstack-2016-09-01", :file => "eucalyptus-devstack-2016-09-01.box",
+  },
+  "open-release/eucalyptus.1rc2" => {
+    :name => "eucalyptus-devstack-2016-08-19", :file => "eucalyptus-devstack-2016-08-19.box",
+  },
+  "open-release/eucalyptus.1" => {
+    :name => "eucalyptus-devstack-2016-08-19", :file => "eucalyptus-devstack-2016-08-19.box",
+  },
+  "open-release/eucalyptus.2" => {
+    :name => "eucalyptus-devstack-2016-09-01", :file => "eucalyptus-devstack-2016-09-01.box",
+  },
   # Note: the devstack and fullstack boxes differ, because devstack had an issue
   # that needed fixing, but it didn't affect fullstack.
   "named-release/dogwood.rc" => {
@@ -79,15 +109,7 @@ openedx_releases = {
   # },
 }
 openedx_releases.default = {
-  :name => "dogwood-devstack-2016-03-09", :file => "dogwood-devstack-2016-03-09.box",
-}
-openedx_releases_vmware = {
-  "named-release/birch" => {
-    :name => "birch-devstack-vmware", :file => "20150610-birch-devstack-vmware.box",
-  },
-}
-openedx_releases_vmware.default = {
-  :name => "kifli-devstack-vmware", :file => "20140829-kifli-devstack-vmware.box",
+  :name => "eucalyptus-devstack-2016-09-01", :file => "eucalyptus-devstack-2016-09-01.box",
 }
 rel = ENV['OPENEDX_RELEASE']
 
@@ -143,15 +165,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Allow DNS to work for Ubuntu 12.10 host
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-  end
-
-  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
-    config.vm.provider vmware_provider do |v, override|
-      override.vm.box     = openedx_releases_vmware[rel][:name]
-      override.vm.box_url = "http://files.edx.org/vagrant-images/#{openedx_releases_vmware[rel][:file]}"
-      v.vmx["memsize"] = MEMORY.to_s
-      v.vmx["numvcpus"] = CPU_COUNT.to_s
-    end
   end
 
   # Use vagrant-vbguest plugin to make sure Guest Additions are in sync


### PR DESCRIPTION
There were are lot of commits not in appsembler/master that were in amc and testdrive branches but likely that's because we cherry picked those from somewhere. There were not conflicts other than in our own files which I think I've resolved.

This allows us deploy testdrive and AMC from appsembler/master and not have to have diffferent branches for each of those. AMC and testdrive should converge into a single THING sometime soon but since they are 2 different entities now it makes sense to have 2 different playbooks.

See Makefile for invocation instructions and how to deploy to either of those (AMC or testdrive).

Hopefully the naming is cleared up now.

Pair PR is in the edx-configs repo here: https://github.com/noderabbit-team/edx-configs/pull/7