### PR TITLE
Clean up and alert Sentry on backup failures

### DIFF
--- a/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy.yml
@@ -8,14 +8,21 @@
   hosts: "mongo-server"
   sudo: True
   gather_facts: True
+  vars:
+    BACKUPS_MONGO: yes
+    BACKUPS_MYSQL: no
   roles:
   - { role: swapfile, SWAPFILE_SIZE: "2GB" }
   - mongo
+  - backups
 
 - name: Configure mysql
   hosts: "mysql-server"
   sudo: True
   gather_facts: True
+  vars:
+    BACKUPS_MONGO: no
+    BACKUPS_MYSQL: yes
   vars_files:
   - roles/edxapp/defaults/main.yml
   - roles/xqueue/defaults/main.yml
@@ -25,6 +32,7 @@
   - { role: swapfile, SWAPFILE_SIZE: "2GB" }
   - mysql
   - edxlocal
+  - backups
 
 - name: Configure instance(s)
   hosts: "edxapp-server"

--- a/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy_cloud_sql.yml
+++ b/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy_cloud_sql.yml
@@ -7,12 +7,16 @@
   hosts: "mongo-server"
   sudo: True
   gather_facts: True
+  vars:
+    BACKUPS_MONGO: yes
+    BACKUPS_MYSQL: no
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - mongo
     - oraclejdk
     - elasticsearch
     - memcached
+    - backups
 
 - name: Configure stateless edxapp server
   hosts: "edxapp-server"

--- a/playbooks/appsemblerPlaybooks/multiserver_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/multiserver_deploy.yml
@@ -8,13 +8,20 @@
   hosts: "mongo-server"
   sudo: True
   gather_facts: True
+  vars:
+    BACKUPS_MONGO: yes
+    BACKUPS_MYSQL: no
   roles:
   - mongo
+  - backups
 
 - name: Configure mysql
   hosts: "mysql-server"
   sudo: True
   gather_facts: True
+  vars:
+    BACKUPS_MONGO: no
+    BACKUPS_MYSQL: yes
   vars_files:
   - roles/edxapp/defaults/main.yml
   - roles/xqueue/defaults/main.yml
@@ -22,6 +29,7 @@
   - roles/analytics_api/defaults/main.yml
   roles:
   - edxlocal
+  - backups
 
 - name: Configure instance(s)
   hosts: "edxapp-server"

--- a/playbooks/roles/backups/defaults/main.yml
+++ b/playbooks/roles/backups/defaults/main.yml
@@ -6,6 +6,7 @@ BACKUPS_BUCKET: ''
 BACKUPS_AWS_ACCESS_KEY_ID: ''
 BACKUPS_AWS_SECRET_ACCESS_KEY: ''
 BACKUPS_DIR: '/tmp/db_backups'
+BACKUPS_SENTRY_DSN: ''
 
 # gs: Google Cloud Storage
 # s3: Amazon Simple Storage Service

--- a/playbooks/roles/backups/files/backup.py
+++ b/playbooks/roles/backups/files/backup.py
@@ -154,10 +154,13 @@ def clean_up(backup_path):
     if os.path.isfile(backup_tar):
         os.remove(backup_tar)
 
-    if os.path.isdir(backup_path):
-        shutil.rmtree(backup_path)
-    elif os.path.isfile(backup_path):
-        os.remove(backup_path)
+    try:
+        if os.path.isdir(backup_path):
+            shutil.rmtree(backup_path)
+        elif os.path.isfile(backup_path):
+            os.remove(backup_path)
+    except OSError:
+        logging.exception('Removing files at {} failed!'.format(backup_path))
 
 
 def restore(service_name, backup_path, uncompress=True, settings=None):
@@ -305,16 +308,16 @@ def _main():
     args = _parse_args()
 
     program_name = os.path.basename(sys.argv[0])
-    backup_dir = (args.backup_dir or os.environ.get('BACKUP_DIR') or
-                  '/tmp/db_backups')
+    backup_dir = (args.backup_dir or os.environ.get('BACKUP_DIR',
+                                                    '/tmp/db_backups'))
     bucket = args.bucket or os.environ.get('BACKUP_BUCKET')
     compress = args.compress
-    provider = args.provider or os.environ.get('BACKUP_PROVIDER') or 'gs'
+    provider = args.provider or os.environ.get('BACKUP_PROVIDER', 'gs')
     restore_path = args.restore_path
     s3_id = args.s3_id or os.environ.get('BACKUP_AWS_ACCESS_KEY_ID')
     s3_key = args.s3_key or os.environ.get('BACKUP_AWS_SECRET_ACCESS_KEY')
-    settings = args.settings or os.environ.get('BACKUP_SETTINGS') or 'aws_appsembler'
-    sentry_dsn = args.sentry_dsn or os.environ.get('BACKUPS_SENTRY_DSN') or ''
+    settings = args.settings or os.environ.get('BACKUP_SETTINGS', 'aws_appsembler')
+    sentry_dsn = args.sentry_dsn or os.environ.get('BACKUPS_SENTRY_DSN', '')
     service = args.service
 
     sentry = raven.Client(sentry_dsn)
@@ -336,9 +339,11 @@ def _main():
                 upload_to_s3(backup_path, bucket, aws_access_key_id=s3_id,
                              aws_secret_access_key=s3_key)
             else:
-                error_msg = 'Error occurred while compressing backup'
+                error_msg = ('Invalid storage provider specified. Please use '
+                             '"gs" or "s3".')
                 logging.warning(error_msg)
         except:
+            logging.exception("The backup failed!")
             sentry.captureException()
         finally:
             clean_up(backup_path.replace('.tar.gz', ''))

--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -11,12 +11,14 @@
   when: BACKUPS_PROVIDER == 'gs'
   tags: ['backups']
 
-- name: Install boto plugin for Google Cloud Storage
+- name: Install Python packages required for backup script
   pip: name={{ item.name }} version={{ item.version }}
   with_items:
     - {name: gcs-oauth2-boto-plugin, version: 1.9}
     - {name: oauth2client, version: 1.5.2}
     - {name: pyopenssl, version: 0.15.1}
+    - {name: cryptography, version: 1.4}
+    - {name: raven, version: 5.27.1}
   when: BACKUPS_PROVIDER == 'gs'
   tags: ['backups']
 
@@ -41,11 +43,11 @@
   tags: ['backups']
 
 - name: Copy database backup script
-  template: src=backup.py dest=/usr/local/bin/edx_backup owner=root group=root mode=0700
+  copy: src=backup.py dest=/usr/local/bin/edx_backup owner=root group=root mode=0700
   tags: ['backups']
 
 - name: Copy database restore script
-  template: src=backup.py dest=/usr/local/bin/edx_restore owner=root group=root mode=0700
+  copy: src=backup.py dest=/usr/local/bin/edx_restore owner=root group=root mode=0700
   tags: ['backups']
 
 - name: Create cron job for Mongo backups
@@ -66,6 +68,7 @@
     BACKUP_PROVIDER: '{{ BACKUPS_PROVIDER }}'
     BACKUP_AWS_ACCESS_KEY_ID: '{{ BACKUPS_AWS_ACCESS_KEY_ID }}'
     BACKUP_AWS_SECRET_ACCESS_KEY: '{{ BACKUPS_AWS_SECRET_ACCESS_KEY }}'
+    BACKUPS_SENTRY_DSN: '{{ BACKUPS_SENTRY_DSN }}'
   when: BACKUPS_MONGO and "{{ item.value }}" != ""
   tags: ['backups']
 
@@ -87,5 +90,6 @@
     BACKUP_PROVIDER: '{{ BACKUPS_PROVIDER }}'
     BACKUP_AWS_ACCESS_KEY_ID: '{{ BACKUPS_AWS_ACCESS_KEY_ID }}'
     BACKUP_AWS_SECRET_ACCESS_KEY: '{{ BACKUPS_AWS_SECRET_ACCESS_KEY }}'
+    BACKUPS_SENTRY_DSN: '{{ BACKUPS_SENTRY_DSN }}'
   when: BACKUPS_MYSQL and "{{ item.value }}" != ""
   tags: ['backups']


### PR DESCRIPTION
When backups fail, they aren't properly cleaned up and accumulate on disk. In addition, we have no way of knowing until the disk fills up and we receive an disk space alert. This PR ensures that backups are deleted from the disk and that Sentry is triggered when a backup fails.