### PR TITLE
enterprise tier playbook, mongo 3 fix, mysql new table fix

### DIFF
--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -15,6 +15,8 @@
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - mongo_3_0
     - backups
+    - role: stackdriver
+      when: "stackdriver_api_key != ''"
 
 
 - name: Install Mongo Backups
@@ -27,6 +29,8 @@
     COMMON_ENABLE_BACKUPS: True
   roles:
     - mongo_3_0
+    - role: stackdriver
+      when: "stackdriver_api_key != ''"
 
 
 - name: Install Needed Packages On Services Server
@@ -39,6 +43,8 @@
     - oraclejdk
     - elasticsearch
     - memcached
+    - role: stackdriver
+      when: "stackdriver_api_key != ''"
 
 
 - name: Configure Stateless edxapp-server
@@ -48,6 +54,9 @@
   vars:
     migrate_db: "yes"
     openid_workaround: True
+    SANDBOX_ENABLE_ECOMMERCE: False
+    COMMON_ENABLE_INSIGHTS: False
+    COMMON_ENABLE_OAUTH_CLIENT: False
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - sudo
@@ -65,6 +74,8 @@
     - demo
     - oauth_client_setup
     - forum
+    - role: stackdriver
+      when: "stackdriver_api_key != ''"
 
 
 - name: Install xqueue, notifier and rabbitmq on services

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -19,7 +19,7 @@
       when: "stackdriver_api_key != ''"
 
 
-- name: Install Mongo Backups
+- name: Install Mongo on arbiter
   hosts: "mongo-arbiter"
   sudo: True
   gather_facts: True

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -72,6 +72,7 @@
     - edxapp
     - edx_notes_api
     - demo
+      when: "INSTALL_DEMO_DATA"
     - oauth_client_setup
     - forum
     - role: stackdriver

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -71,7 +71,6 @@
     - demo
     - oauth_client_setup
     - forum
-    - edx_ansible
 
 
 - name: Install xqueue, notifier and rabbitmq on services

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -71,7 +71,7 @@
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - edx_notes_api
-    - demo
+    - role: demo
       when: "INSTALL_DEMO_DATA"
     - oauth_client_setup
     - forum

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -3,53 +3,60 @@
 # Appsembler pro tier deployment
 # Docs: https://github.com/appsembler/openedx-docs/blob/master/openedx/pro_tier_deployment.md
 
-# - name: Install Mongo Replica Set
-#   hosts: "mongo-servers"
-#   sudo: True
-#   gather_facts: True
-#   vars:
-#     BACKUPS_MONGO: no
-#     BACKUPS_MYSQL: no
-#   roles:
-#     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
-#     - mongo_3_0
-
-# - name: Install Mongo Replica Set Secondary
-#   hosts: "mongo-server-1"
-#   sudo: True
-#   gather_facts: True
-#   vars:
-#     BACKUPS_MONGO: no
-#     BACKUPS_MYSQL: no
-#   roles:
-#     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
-#     - mongo
+- name: Install Mongo Replica Set
+  hosts: "mongo-servers"
+  sudo: True
+  gather_facts: True
+  vars:
+    BACKUPS_MONGO: False
+    BACKUPS_MYSQL: False
+    COMMON_ENABLE_BACKUPS: False
+  roles:
+    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+    - mongo_3_0
 
 
+- name: Install Mongo Backups
+  hosts: "mongo-arbiter"
+  sudo: True
+  gather_facts: True
+  vars:
+    BACKUPS_MONGO: True
+    BACKUPS_MYSQL: False
+    COMMON_ENABLE_BACKUPS: True
+  roles:
+    - backups
 
 
-- name: Install Services Server
+- name: Install Needed Packages On Services Server
   hosts: "services-server"
   sudo: True
   gather_facts: True
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - role: sudo
     - oraclejdk
     - elasticsearch
     - memcached
 
-- name: Configure stateless edxapp server
+
+- name: Configure Stateless edxapp-server
   hosts: "edxapp-servers"
   sudo: True
   gather_facts: True
   vars:
     migrate_db: "yes"
     openid_workaround: True
+    # Set to false if deployed behind another proxy/load balancer.
+    NGINX_SET_X_FORWARDED_HEADERS: False
+    # These should stay false for the public AMI
+    SANDBOX_ENABLE_ECOMMERCE: False
+    COMMON_ENABLE_INSIGHTS: False
+    COMMON_ENABLE_OAUTH_CLIENT: False
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - role: sudo
     - mysql_init
-    # - role: scorm
-    #   when: "{{ EDXAPP_XBLOCK_SETTINGS }}.get('ScormXBlock', False)"
     - role: nginx
       nginx_sites:
       - cms
@@ -64,8 +71,7 @@
     - oauth_client_setup
     - forum
     - edx_ansible
-    # scorm if desired.  requires more setup in server-vars
-    # see https://github.com/appsembler/ssla-scorm-player/blob/nyif/master/README.md
+
 
 - name: Install xqueue, notifier and rabbitmq on services
   hosts: "services-server"
@@ -83,6 +89,7 @@
     - notifier
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
     - { role: "xqueue", update_users: True }
+
 
 # must come after xqueue running
 - name: Install certs

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -1,0 +1,98 @@
+---
+
+# Appsembler pro tier deployment
+# Docs: https://github.com/appsembler/openedx-docs/blob/master/openedx/pro_tier_deployment.md
+
+# - name: Install Mongo Replica Set
+#   hosts: "mongo-servers"
+#   sudo: True
+#   gather_facts: True
+#   vars:
+#     BACKUPS_MONGO: no
+#     BACKUPS_MYSQL: no
+#   roles:
+#     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+#     - mongo_3_0
+
+# - name: Install Mongo Replica Set Secondary
+#   hosts: "mongo-server-1"
+#   sudo: True
+#   gather_facts: True
+#   vars:
+#     BACKUPS_MONGO: no
+#     BACKUPS_MYSQL: no
+#   roles:
+#     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+#     - mongo
+
+
+
+
+- name: Install Services Server
+  hosts: "services-server"
+  sudo: True
+  gather_facts: True
+  roles:
+    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - oraclejdk
+    - elasticsearch
+    - memcached
+
+- name: Configure stateless edxapp server
+  hosts: "edxapp-servers"
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    openid_workaround: True
+  roles:
+    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - mysql_init
+    # - role: scorm
+    #   when: "{{ EDXAPP_XBLOCK_SETTINGS }}.get('ScormXBlock', False)"
+    - role: nginx
+      nginx_sites:
+      - cms
+      - lms
+      - forum
+      nginx_default_sites:
+      - lms
+    - { role: 'edxapp', celery_worker: True }
+    - edxapp
+    - edx_notes_api
+    - demo
+    - oauth_client_setup
+    - forum
+    - edx_ansible
+    # scorm if desired.  requires more setup in server-vars
+    # see https://github.com/appsembler/ssla-scorm-player/blob/nyif/master/README.md
+
+- name: Install xqueue, notifier and rabbitmq on services
+  hosts: "services-server"
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+  roles:
+    - edxapp_common
+    - mysql_init
+    - role: nginx
+      nginx_sites:
+      - xqueue
+    - { role: 'rabbitmq', rabbitmq_ip: '0.0.0.0' }
+    - notifier
+    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
+    - { role: "xqueue", update_users: True }
+
+# must come after xqueue running
+- name: Install certs
+  hosts: "edxapp-servers"
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+  roles:
+    - certs
+    - role: nginx
+      nginx_sites:
+      - certs

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -23,10 +23,6 @@
   hosts: "mongo-arbiter"
   sudo: True
   gather_facts: True
-  vars:
-    BACKUPS_MONGO: True
-    BACKUPS_MYSQL: False
-    COMMON_ENABLE_BACKUPS: True
   roles:
     - mongo_3_0
     - role: stackdriver

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -48,12 +48,6 @@
   vars:
     migrate_db: "yes"
     openid_workaround: True
-    # Set to false if deployed behind another proxy/load balancer.
-    NGINX_SET_X_FORWARDED_HEADERS: False
-    # These should stay false for the public AMI
-    SANDBOX_ENABLE_ECOMMERCE: False
-    COMMON_ENABLE_INSIGHTS: False
-    COMMON_ENABLE_OAUTH_CLIENT: False
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - sudo

--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -322,7 +322,7 @@
 - name: create mongodb users in a replica set
   mongodb_user:
     database: "{{ item.database }}"
-    login_database: 'admin'
+    #login_database: 'admin'
     login_user: "{{ MONGO_ADMIN_USER }}"
     login_password: "{{ MONGO_ADMIN_PASSWORD }}"
     name: "{{ item.user }}"

--- a/playbooks/roles/mysql_init/defaults/main.yml
+++ b/playbooks/roles/mysql_init/defaults/main.yml
@@ -44,6 +44,11 @@ mysql_database_users:
       pass: "{{ EDXAPP_MYSQL_PASSWORD | default(None) }}"
     }
   - {
+      db: "{{ EDXAPP_MYSQL_CSMH_DB_NAME | default(None) }}",
+      user: "{{ EDXAPP_MYSQL_CSMH_USER | default(None) }}",
+      pass: "{{ EDXAPP_MYSQL_CSMH_PASSWORD | default(None) }}"
+    }
+  - {
       db: "{{ PROGRAMS_DEFAULT_DB_NAME | default(None) }}",
       user: "{{ PROGRAMS_DATABASES.default.USER | default(None) }}",
       pass: "{{ PROGRAMS_DATABASES.default.PASSWORD | default(None) }}"


### PR DESCRIPTION
Here is the new playbook for enterprise deploys, with a fix for mongo 3 (we need mongo 3 for the replica set) and mysql_init vars for a new edxapp mysql table in eucalyptus.