### PR TITLE
Change permissions for MySQL TLS certs

### DIFF
--- a/playbooks/roles/mysql_init/defaults/main.yml
+++ b/playbooks/roles/mysql_init/defaults/main.yml
@@ -64,3 +64,5 @@ mysql_ca_cert: ''
 mysql_client_cert_path: '/etc/ssl/certs/mysql-client-cert.pem'
 mysql_client_key_path: '/etc/ssl/certs/mysql-client-key.pem'
 mysql_ca_cert_path: '/etc/ssl/certs/mysql-server-ca.pem'
+mysql_cert_owner: "{{ edxapp_user }}"
+mysql_cert_group: "{{ common_web_user }}"

--- a/playbooks/roles/mysql_init/tasks/main.yml
+++ b/playbooks/roles/mysql_init/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Copy TLS certificates
   copy: >
     content="{{ item.content }}" dest="{{ item.dest }}"
-    owner="{{ common_web_user }}" group="{{ common_web_user }}" mode=400
+    owner="{{ mysql_cert_owner }}" group="{{ mysql_cert_group }}" mode=0440
   with_items:
     - { content: "{{ mysql_client_cert }}", dest: "{{ mysql_client_cert_path }}" }
     - { content: "{{ mysql_client_key  }}", dest: "{{ mysql_client_key_path }}" }


### PR DESCRIPTION
Services running as `www-data` and management commands running as `edxapp` need to be able to read TLS certs. By default, the owner of the certs is now `edxapp` and the group is `www-data`. Both owner and group have read-only permissions.