### PR TITLE
Make TLS certs for MySQL world-readable

### DIFF
--- a/playbooks/roles/mysql_init/tasks/main.yml
+++ b/playbooks/roles/mysql_init/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Copy TLS certificates
   copy: >
     content="{{ item.content }}" dest="{{ item.dest }}"
-    owner="{{ mysql_cert_owner }}" group="{{ mysql_cert_group }}" mode=0440
+    owner="{{ mysql_cert_owner }}" group="{{ mysql_cert_group }}" mode=0444
   with_items:
     - { content: "{{ mysql_client_cert }}", dest: "{{ mysql_client_cert_path }}" }
     - { content: "{{ mysql_client_key  }}", dest: "{{ mysql_client_key_path }}" }


### PR DESCRIPTION
Several users need read access to the certs to run migrations. Unfortunately, it's not straightforward to give only those users access to the certs in the configuration repo. While not ideal, I don't consider this a major security issue since users still need credentials to access the database and TLS isn't (currently) strictly required to connect.