### PR TITLE
Change owner of MySQL certs to `common_web_user`

### DIFF
--- a/playbooks/roles/mysql_init/defaults/main.yml
+++ b/playbooks/roles/mysql_init/defaults/main.yml
@@ -64,5 +64,5 @@ mysql_ca_cert: ''
 mysql_client_cert_path: '/etc/ssl/certs/mysql-client-cert.pem'
 mysql_client_key_path: '/etc/ssl/certs/mysql-client-key.pem'
 mysql_ca_cert_path: '/etc/ssl/certs/mysql-server-ca.pem'
-mysql_cert_owner: "{{ edxapp_user }}"
+mysql_cert_owner: "{{ common_web_user }}"
 mysql_cert_group: "{{ common_web_user }}"


### PR DESCRIPTION
The `edxapp` user may not exist on every server, but `{{ common_web_user }}` (aka `www-data`) does. A [previous PR](https://github.com/appsembler/configuration/pull/51) changes the cert permissions to 0444, so other users like `edxapp` and `xqueue` will still be able to read them.