### PR TITLE
Add nginx health check for LMS

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -24,6 +24,9 @@ NGINX_USERS:
     password: "{{ COMMON_HTPASSWD_PASS }}"
     state: present
 
+NGINX_HEALTH_CHECK_ENABLED: False
+NGINX_HEALTH_CHECK_USER_AGENT: ""
+
 NGINX_ENABLE_SSL: False
 NGINX_REDIRECT_TO_HTTPS: False
 # Set these to real paths on your

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -4,6 +4,13 @@
   {%- set default_site = "" -%}
 {%- endif -%}
 
+{% if NGINX_HEALTH_CHECK_ENABLED %}
+map $http_user_agent $healthcheck {
+ default 0;
+ "{{ NGINX_HEALTH_CHECK_USER_AGENT }}" 1;
+}
+{% endif %}
+
 upstream lms-backend {
     {% for host in nginx_lms_gunicorn_hosts %}
         server {{ host }}:{{ edxapp_lms_gunicorn_port }} fail_timeout=0;
@@ -64,6 +71,12 @@ error_page {{ k }} {{ v }};
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
+  {% if NGINX_HEALTH_CHECK_ENABLED %}
+  if ($healthcheck) {
+  return 200;
+  }
+  {% endif %}
 
 
   # Nginx does not support nested condition or or conditions so


### PR DESCRIPTION
The GCP HTTP(S) load balancer will only forward requests to healthy nodes. For a node to be considered healthy it must return a 200 status code. This PR allows us to return 200 based on the user agent.

When using a GCP load balancer, we need to set:
- `NGINX_HEALTH_CHECK_ENABLED: True`
- `NGINX_HEALTH_CHECK_USER_AGENT: "GoogleHC/1.0"`