### PR TITLE
Support TLS for Mongo3

### DIFF
--- a/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy.yml
@@ -48,6 +48,13 @@
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     #COMMON_ENABLE_SPLUNKFORWARDER: False
+  pre_tasks:
+    # This is dirty, but better than setting in every server vars file
+    - set_fact:
+        EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "/edx/etc/edxapp/mongodb.pem"
+        EDXAPP_MONGO_SSL_CA_CERT_PATH: "/edx/etc/edxapp/ca.pem"
+      when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
+      tags: always
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: scorm

--- a/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy_cloud_sql.yml
+++ b/playbooks/appsemblerPlaybooks/dogwood_multiserver_deploy_cloud_sql.yml
@@ -26,6 +26,13 @@
     migrate_db: "yes"
     openid_workaround: True
     COMMON_ENABLE_DATADOG: False
+  pre_tasks:
+    # This is dirty, but better than setting in every server vars file
+    - set_fact:
+        EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "/edx/etc/edxapp/mongodb.pem"
+        EDXAPP_MONGO_SSL_CA_CERT_PATH: "/edx/etc/edxapp/ca.pem"
+      when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
+      tags: always
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - mysql_init

--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -53,6 +53,13 @@
     SANDBOX_ENABLE_ECOMMERCE: False
     COMMON_ENABLE_INSIGHTS: False
     COMMON_ENABLE_OAUTH_CLIENT: False
+  pre_tasks:
+    # This is dirty, but better than setting in every server vars file
+    - set_fact:
+        EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "/edx/etc/edxapp/mongodb.pem"
+        EDXAPP_MONGO_SSL_CA_CERT_PATH: "/edx/etc/edxapp/ca.pem"
+      when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
+      tags: always
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - sudo

--- a/playbooks/appsemblerPlaybooks/eucalyptus_pro_server.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_pro_server.yml
@@ -31,6 +31,13 @@
   vars:
     migrate_db: "yes"
     openid_workaround: True
+  pre_tasks:
+    # This is dirty, but better than setting in every server vars file
+    - set_fact:
+        EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "/edx/etc/edxapp/mongodb.pem"
+        EDXAPP_MONGO_SSL_CA_CERT_PATH: "/edx/etc/edxapp/ca.pem"
+      when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
+      tags: always
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - sudo

--- a/playbooks/appsemblerPlaybooks/multiserver_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/multiserver_deploy.yml
@@ -45,6 +45,13 @@
     # These should stay false for the public AMI
     #COMMON_ENABLE_DATADOG: False
     #COMMON_ENABLE_SPLUNKFORWARDER: False
+  pre_tasks:
+    # This is dirty, but better than setting in every server vars file
+    - set_fact:
+        EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "/edx/etc/edxapp/mongodb.pem"
+        EDXAPP_MONGO_SSL_CA_CERT_PATH: "/edx/etc/edxapp/ca.pem"
+      when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
+      tags: always
   roles:
     - role: scorm
       when: "{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock }}"    

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -73,6 +73,15 @@ EDXAPP_MONGO_PORT: 27017
 EDXAPP_MONGO_USER: 'edxapp'
 EDXAPP_MONGO_DB_NAME: 'edxapp'
 EDXAPP_MONGO_USE_SSL: False
+EDXAPP_MONGO_SSL_CLIENT_KEY: ""
+EDXAPP_MONGO_SSL_CLIENT_CERT: ""
+EDXAPP_MONGO_SSL_CA_CERT: ""
+EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: !!null
+EDXAPP_MONGO_SSL_CA_CERT_PATH: !!null
+
+# When `EDXAPP_MONGO_USE_SSL: True`, set
+# EDXAPP_MONGO_SSL_CLIENT_CERT_PATH: "{{ EDXAPP_CFG_DIR }}/mongodb.pem"
+# EDXAPP_MONGO_SSL_CA_CERT_PATH: "{{ EDXAPP_CFG_DIR }}/ca.pem"
 
 EDXAPP_MYSQL_DB_NAME: 'edxapp'
 EDXAPP_MYSQL_USER: 'edxapp001'
@@ -689,6 +698,8 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   user: "{{ EDXAPP_MONGO_USER }}"
   collection:  'modulestore'
   ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+  ssl_certfile: "{{ EDXAPP_MONGO_SSL_CLIENT_CERT_PATH }}"
+  ssl_ca_certs: "{{ EDXAPP_MONGO_SSL_CA_CERT_PATH }}"
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore
@@ -768,6 +779,8 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
       port: "{{ EDXAPP_MONGO_PORT }}"
       user: "{{ EDXAPP_MONGO_USER }}"
       ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+      ssl_certfile: "{{ EDXAPP_MONGO_SSL_CLIENT_CERT_PATH }}"
+      ssl_ca_certs: "{{ EDXAPP_MONGO_SSL_CA_CERT_PATH }}"
     ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
     DOC_STORE_CONFIG: *edxapp_generic_default_docstore
   DATABASES: "{{ edxapp_databases }}"

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -1,4 +1,31 @@
 ---
+
+- name: copy Mongo CA certificate
+  copy: >
+    content="{{ EDXAPP_MONGO_SSL_CA_CERT }}"
+    dest="{{ EDXAPP_MONGO_SSL_CA_CERT_PATH }}"
+    mode=0440
+    owner=edxapp
+    group=www-data
+  when: EDXAPP_MONGO_SSL_CA_CERT_PATH != None
+  tags:
+    - install
+    - install:configuration
+    - edxapp_cfg
+
+- name: copy Mongo client key and certificate
+  copy: >
+    content="{{ EDXAPP_MONGO_SSL_CLIENT_KEY ~ EDXAPP_MONGO_SSL_CLIENT_CERT }}"
+    dest="{{ EDXAPP_MONGO_SSL_CLIENT_CERT_PATH }}"
+    mode=0440
+    owner=edxapp
+    group=www-data
+  when: EDXAPP_MONGO_SSL_CLIENT_CERT_PATH != None
+  tags:
+    - install
+    - install:configuration
+    - edxapp_cfg
+
 - name: create application and auth config
   template:
     src: "{{ item[0] }}.{{ item[1] }}.json.j2"

--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -44,6 +44,11 @@ MONGO_BIND_IP: 127.0.0.1
 MONGO_REPL_SET: "rs0"
 MONGO_AUTH: true
 
+MONGO_SSL_MODE: "disabled"
+MONGO_SSL_CA_CERT: ""
+MONGO_SSL_SERVER_KEY: ""
+MONGO_SSL_SERVER_CERT: ""
+
 # Cluster member configuration
 # Fed directly into mongodb_replica_set module
 MONGO_RS_CONFIG:

--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -193,6 +193,32 @@
     - "install:configuration"
     - "logrotate"
 
+- name: copy CA certificate
+  copy: >
+    content="{{ MONGO_SSL_CA_CERT }}"
+    dest="{{ mongo_data_dir }}/ca.pem"
+    mode=0600
+    owner=mongodb
+    group=mongodb
+  when: MONGO_SSL_CA_CERT != ""
+  tags:
+    - "install"
+    - "install:configuration"
+
+- name: copy server key and certificate
+  copy: >
+    content="{{ MONGO_SSL_SERVER_KEY ~ '\n' ~ MONGO_SSL_SERVER_CERT }}"
+    dest="{{ mongo_data_dir }}/server.pem"
+    mode=0600
+    owner=mongodb
+    group=mongodb
+  when:
+    - MONGO_SSL_SERVER_KEY != ""
+    - MONGO_SSL_SERVER_CERT != ""
+  tags:
+    - "install"
+    - "install:configuration"
+
 - name: restart mongo service if we changed our configuration
   service:
     name: mongod

--- a/playbooks/roles/mongo_3_0/templates/mongod.conf.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongod.conf.j2
@@ -39,6 +39,12 @@ security:
 
 {% endif %}
 net:
+  ssl:
+    mode: {{ MONGO_SSL_MODE }}
+{% if MONGO_SSL_MODE != "disabled" %}
+    PEMKeyFile: {{ mongo_data_dir }}/server.pem
+    CAFile: {{ mongo_data_dir }}/ca.pem
+{% endif %}
 {% if MONGO_CLUSTERED is not defined %}
   {# Bind to all ips(default) if in clustered mode, 
      otherwise only to the specified local ip. #}   

--- a/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
@@ -33,6 +33,12 @@ security:
   authorization: {{ MONGO_AUTH | ternary("enabled", "disabled") }}
 
 net:
+  ssl:
+    mode: {{ MONGO_SSL_MODE }}
+{% if MONGO_SSL_MODE != "disabled" %}
+    PEMKeyFile: {{ mongo_data_dir }}/server.pem
+    CAFile: {{ mongo_data_dir }}/ca.pem
+{% endif %}
 {% if MONGO_CLUSTERED is not defined %}
   {## Bind to all ips(default) if in clustered mode, 
   # otherwise only to the specified local ip.


### PR DESCRIPTION
This PR supports enabling TLS for connections to Mongo3. To enable TLS on the Mongo side, set `MONGO_SSL_MODE: "allowSSL"`. TLS can be forced with `MONGO_SSL_MODE: "requireSSL"`, but shouldn't be used until the forum supports TLS connections to Mongo. When TLS is enabled, a CA certificate must be provided (`MONGO_SSL_CA_CERT`), along with a server key (`MONGO_SSL_SERVER_KEY`) and server cert (`MONGO_SSL_SERVER_CERT`) signed by the provided CA.

The LMS/CMS can connect to Mongo3 over TLS by setting `EDXAPP_MONGO_USE_SSL: True` and providing a CA cert and client key/cert. The CA cert must be the same one used to sign the Mongo
server cert and the client cert. When TLS is enabled, `EDXAPP_MONGO_SSL_CLIENT_CERT_PATH` and `EDXAPP_MONGO_SSL_CA_CERT_PATH` must be set to the paths where the client certificate and key live on the server. The playbooks should take care of setting these so that they don't need to be set in every server vars file.

CA, server, and client keys and certificates can be generated using [`ax create-tls-certs`](https://github.com/appsembler/ax/pull/12).

The forum also talks to Mongo, but changes are required in the `cs_comments_service` repo to support TLS. This PR does _not_ make the necessary changes to support TLS for the forum.

Note that TLS can only be enabled for Mongo3 since community versions of Mongo2 do not support TLS. In addition, the forum does not support Mongo3 until Eucalyptus. Therefore, both Mongo3 and Eucalyptus are required to enable TLS for Mongo connections.

[Mongo docs](https://docs.mongodb.com/manual/tutorial/configure-ssl/)