### PR TITLE
Auto restart for Supervisor programs when unexpected failure 

### DIFF
--- a/playbooks/roles/analytics_api/templates/edx/app/supervisor/conf.d.available/analytics_api.conf.j2
+++ b/playbooks/roles/analytics_api/templates/edx/app/supervisor/conf.d.available/analytics_api.conf.j2
@@ -9,3 +9,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/certs/templates/certs.conf.j2
+++ b/playbooks/roles/certs/templates/certs.conf.j2
@@ -7,3 +7,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries={{ common_supervisor_program_startretries }}

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -134,6 +134,10 @@ common_git_ppa: "ppa:git-core/ppa"
 # to supervisors 'conf.d' directory.
 disable_edx_services: False
 
+common_supervisor_program_autorestart: true
+common_supervisor_program_startsecs: 10
+common_supervisor_program_startretries: 1
+
 # Some apps run differently in dev mode(forums)
 # so different start scripts are generated in dev mode.
 devstack: False

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -134,7 +134,7 @@ common_git_ppa: "ppa:git-core/ppa"
 # to supervisors 'conf.d' directory.
 disable_edx_services: False
 
-common_supervisor_program_autorestart: true
+common_supervisor_program_autorestart: unexpected
 common_supervisor_program_startsecs: 10
 common_supervisor_program_startretries: 1
 

--- a/playbooks/roles/ecommerce/templates/edx/app/supervisor/conf.d.available/ecommerce.conf.j2
+++ b/playbooks/roles/ecommerce/templates/edx/app/supervisor/conf.d.available/ecommerce.conf.j2
@@ -10,3 +10,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/ecomworker/templates/edx/app/supervisor/conf.d.available/ecomworker.conf.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/supervisor/conf.d.available/ecomworker.conf.j2
@@ -10,3 +10,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/edx_notes_api/templates/edx/app/supervisor/conf.d.available/edx_notes_api.conf.j2
+++ b/playbooks/roles/edx_notes_api/templates/edx/app/supervisor/conf.d.available/edx_notes_api.conf.j2
@@ -11,3 +11,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -15,3 +15,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries={{ common_supervisor_program_startretries }}

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -15,3 +15,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -10,6 +10,9 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}
 
 {% endfor %}
 

--- a/playbooks/roles/forum/templates/forum.conf.j2
+++ b/playbooks/roles/forum/templates/forum.conf.j2
@@ -7,3 +7,6 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 stopsignal=QUIT
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/insights/templates/edx/app/supervisor/conf.d.available/insights.conf.j2
+++ b/playbooks/roles/insights/templates/edx/app/supervisor/conf.d.available/insights.conf.j2
@@ -9,3 +9,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/programs/templates/edx/app/supervisor/conf.d.available/programs.conf.j2
+++ b/playbooks/roles/programs/templates/edx/app/supervisor/conf.d.available/programs.conf.j2
@@ -10,3 +10,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -17,3 +17,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}

--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -18,3 +18,6 @@ stderr_logfile={{ xqwatcher_supervisor_log_dir }}/%(program_name)s-stderr.log
 environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}
 killasgroup=true
 stopasgroup=true
+autorestart={{ common_supervisor_program_autorestart }}
+startsecs={{ common_supervisor_program_startsecs }}
+startretries= {{ common_supervisor_program_startretries }}


### PR DESCRIPTION
Not sure why, but default edx configuration does not set up Supervisor to restart programs which fail unexpectedly.  This PR sets autorestart  to 'unexpected', and sets common defaults for number of start attempts and number of seconds a program must stay up to count as started.  

cc @natea 