### PR TITLE
appsembler/eucalyptus/feature/edx notes https

### DIFF
--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -103,6 +103,7 @@ edx_notes_api_gunicorn_port: 8120
 edx_notes_api_gunicorn_timeout: 300
 edx_notes_api_wsgi: notesserver.wsgi:application
 edx_notes_api_nginx_port: 18120
+edx_notes_api_ssl_nginx_port: 443
 edx_notes_api_manage: "{{ edx_notes_api_code_dir }}/manage.py" 
 edx_notes_api_requirements_base: "{{ edx_notes_api_code_dir }}/requirements"
 # Application python requirements

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -6,6 +6,16 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 
 server {
   listen {{ edx_notes_api_nginx_port }};
+
+  {% if NGINX_ENABLE_SSL %}
+  listen {{ edx_notes_api_ssl_nginx_port }} ssl;
+
+  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
+  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% endif %}
+
   server_name {{ NOTES_HOSTNAME }};
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings


### PR DESCRIPTION
The edx-notes API endpoint isn't HTTPS aware by default, but setting:

```
NGINX_REDIRECT_TO_HTTPS: true
```

does force HTTP requests to HTTPS:

https://github.com/edx/configuration/blob/master/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2#L17

the resulting HTTPS request connects to whatever Nginx service is defined as `default` (in most cases, the LMS).

This PR enables HTTPS when:

```
NGINX_ENABLE_SSL: true
```

One thing I'm unsure of is whether or not to set a different default port number for the newly created variable `edx_notes_api_ssl_nginx_port`. Other services have seemingly random port numbers assigned. e.g.: 

- EDXAPP_LMS_SSL_NGINX_PORT: 48000
- EDXAPP_CMS_SSL_NGINX_PORT: 48010
- ECOMMERCE_SSL_NGINX_PORT: 48130
- INSIGHTS_NGINX_SSL_PORT: "18113"