### PR TITLE
Allow separate SSL cert/key for Nginx redirect template

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
@@ -9,8 +9,15 @@ server {
 
   {% if "ssl" in item.value and item.value['ssl'] == true -%}
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+
+  {% if "ssl_cert" in item.value and "ssl_key" in item.value -%}
+  ssl_certificate /etc/ssl/certs/{{ item.value['ssl_cert'] }};
+  ssl_certificate_key /etc/ssl/private/{{ item.value['ssl_key'] }};
+  {% else -%}
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
+  {% endif -%}
+
   {% endif -%}
 
   server_name {% for server in item.value['server_names'] %}


### PR DESCRIPTION
This addresses the case where we need to redirect from one domain with an SSL cert to another domain with a different SSL cert, where both certs are on the server where Nginx is running.  This allows you to use the `nginx_redirect.j2` templates for the `nginx` role, but specify SSL cert and key for each redirecting domain.