### PR TITLE
Always run monit role

### DIFF
--- a/playbooks/appsemblerPlaybooks/monitoring.yml
+++ b/playbooks/appsemblerPlaybooks/monitoring.yml
@@ -14,6 +14,5 @@
     - "{{ appsembler_roles }}/logstash"
     - role: "{{ appsembler_roles }}/stackdriver"
       when: "cloud_provider == 'gcp'"
-    - role: "{{ appsembler_roles }}/monit"
-      when: "cloud_provider == 'azure'"
+    - "{{ appsembler_roles }}/monit"
     - "{{ appsembler_roles }}/snort"


### PR DESCRIPTION
We now use monit to [check static assets](https://github.com/appsembler/roles/pull/16) on all platforms.