### PR TITLE
Exclude `appsembler_usage` frommigrations scripts

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -5,7 +5,7 @@ if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
 fi
 
 {% for db in cms_auth_config.DATABASES.keys() %}
-  {%- if db != 'read_replica' %}
+  {%- (if db != 'read_replica' and db != 'appsembler_usage') %}
 ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -5,7 +5,7 @@ if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
 fi
 
 {% for db in lms_auth_config.DATABASES.keys() %}
-  {%- if db != 'read_replica' %}
+  {%- (if db != 'read_replica' and db != 'appsembler_usage') %}
 ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR excludes `appsembler_usage ` database from the migrations scripts, so the migration doesn’t fail for installations without `appsembler_usage defined.