### PR TITLE
add new relic back to eucalyptus playbooks

### DIFF
--- a/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_enterprise_deploy.yml
@@ -98,6 +98,8 @@
     - notifier
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
     - { role: "xqueue", update_users: True }
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
 
 
 # must come after xqueue running
@@ -112,3 +114,6 @@
     - role: nginx
       nginx_sites:
       - certs
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
+

--- a/playbooks/appsemblerPlaybooks/eucalyptus_pro_server.yml
+++ b/playbooks/appsemblerPlaybooks/eucalyptus_pro_server.yml
@@ -76,6 +76,8 @@
     - notifier
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
     - { role: "xqueue", update_users: True }
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
 
 # must come after xqueue running
 - name: Install certs
@@ -89,3 +91,6 @@
     - role: nginx
       nginx_sites:
       - certs
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
+

--- a/playbooks/eucalyptus_basic_server.yml
+++ b/playbooks/eucalyptus_basic_server.yml
@@ -49,3 +49,6 @@
     - certs
     - stackdriver
     - { role: backups, BACKUPS_MONGO: True, BACKUPS_MYSQL: True, when: COMMON_ENABLE_BACKUPS }
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
+


### PR DESCRIPTION
We need the option to re-enable New Relic for some of our customer deployments (Trinity). I think this is the best way to handle it in Eucalyptus. In Ficus I'll add it to the monitoring.yml playbook. 

Thoughts? 