### PR TITLE
Added ecommerce role to ficus_basic playbook

### DIFF
--- a/playbooks/appsemblerPlaybooks/ficus_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_basic.yml
@@ -3,6 +3,7 @@
 # Appsembler basic tier deployment
 
 - include: monitoring.yml
+  when: SKIP_MONITORING is undefined
 
 - name: Configure basic tier instance
   hosts: edxapp-server
@@ -12,7 +13,7 @@
   vars:
     appsembler_roles: "../../../appsembler-roles"
     migrate_db: "yes"
-    SANDBOX_ENABLE_ECOMMERCE: False
+    ENABLE_ECOMMERCE: False
     COMMON_ENABLE_INSIGHTS: False
     COMMON_ENABLE_OAUTH_CLIENT: False
     COMMON_ENABLE_BACKUPS: True
@@ -36,7 +37,7 @@
     - role: nginx
       nginx_sites:
       - ecommerce
-      when: SANDBOX_ENABLE_ECOMMERCE
+      when: ENABLE_ECOMMERCE
     - mysql
     - mysql_init
     - role: memcache
@@ -47,10 +48,10 @@
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - role: ecommerce
-      when: SANDBOX_ENABLE_ECOMMERCE
+      when: ENABLE_ECOMMERCE
     - role: ecomworker
       ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
-      when: SANDBOX_ENABLE_ECOMMERCE
+      when: ENABLE_ECOMMERCE
     - notifier
     - role: edx_notes_api
       when: "INSTALL_EDX_NOTES is defined and INSTALL_EDX_NOTES"

--- a/playbooks/appsemblerPlaybooks/ficus_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_basic.yml
@@ -33,6 +33,10 @@
       - edx_notes_api
       nginx_default_sites:
       - lms
+    - role: nginx
+      nginx_sites:
+      - ecommerce
+      when: SANDBOX_ENABLE_ECOMMERCE
     - mysql
     - mysql_init
     - role: memcache
@@ -42,6 +46,11 @@
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - { role: 'edxapp', celery_worker: True }
     - edxapp
+    - role: ecommerce
+      when: SANDBOX_ENABLE_ECOMMERCE
+    - role: ecomworker
+      ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
+      when: SANDBOX_ENABLE_ECOMMERCE
     - notifier
     - role: edx_notes_api
       when: "INSTALL_EDX_NOTES is defined and INSTALL_EDX_NOTES"


### PR DESCRIPTION
I copied the ecommerce role additions from the `edx_sandbox.yml` playbook from Eucalyptus. See here: https://github.com/appsembler/configuration/blob/appsembler/eucalyptus/master/playbooks/edx_sandbox.yml

I've only run this modification against `ecommerce-dev`. Meaning I haven't tested installing a non-ecomere server, So would be good to just try it on another dev/staging cloud server as a sanity check.


# Potential Improvement

It seems that we can pull the ecommerce role and its dependencies out into its own playbook. I'm wondering if that would be better than adding it to the "kitchen sink" playbooks (`ficus_basic.yml`, `ficus_pro.yml`, `ficus_enterprise.yml`) 

