### PR TITLE
new nginx role variables for extra http rules.

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -166,3 +166,24 @@ NGINX_CREATE_HTPASSWD_FILE: >
     XQUEUE_ENABLE_BASIC_AUTH|bool or
     XSERVER_ENABLE_BASIC_AUTH|bool
   }}
+
+
+nginx_base_extra_locations: ""
+nginx_base_extra_http: ""
+nginx_lms_specific_extra_locations: ""
+nginx_cms_specific_extra_locations: ""
+nginx_lms_specific_extra_http: ""
+nginx_cms_specific_extra_http: ""
+
+nginx_lms_extra_locations: |
+  {{ nginx_lms_specific_extra_locations }}
+  {{ nginx_base_extra_locations }}
+nginx_cms_extra_locations: |
+  {{ nginx_cms_specific_extra_locations }}
+  {{ nginx_base_extra_locations }}
+nginx_lms_extra_http: |
+  {{ nginx_lms_specific_extra_http }}
+  {{ nginx_base_extra_http }}
+nginx_cms_extra_http: |
+  {{ nginx_cms_specific_extra_http }}
+  {{ nginx_base_extra_http }}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -120,8 +120,12 @@ error_page {{ k }} {{ v }};
 
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
-  
-  {% include "extra_locations_cms.j2" ignore missing %}
+
+  {% if nginx_cms_extra_locations != "" %}
+    {{ nginx_cms_extra_locations }}
+  {% endif %}
 }
 
-{% include "extra_http_cms.j2" ignore missing %}
+{% if nginx_cms_extra_http != "" %}
+  {{ nginx_cms_extra_http }}
+{% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -244,7 +244,9 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
-  {% include "extra_locations_lms.j2" ignore missing %}
+  {% if nginx_lms_extra_locations != "" %}
+    {{ nginx_lms_extra_locations }}
+  {% endif %}
 
   {% if EDXAPP_XBLOCK_SETTINGS.get('ScormXBlock', False) %}
     # asterisk needed so it doesn't break if the file doesn't exist
@@ -253,4 +255,6 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
 
 }
 
-{% include "extra_http_lms.j2" ignore missing %}
+{% if nginx_lms_extra_http != "" %}
+  {{ nginx_lms_extra_http }}
+{% endif %}


### PR DESCRIPTION
For some customers, with integrations with other systems and SSO specially, we need to add extra rules on their nginx configuration, in order to hide and redirect paths to other systems in their architecture.

The old solution developed for Dogwood, consisted in store these rules in separate files, in our configs repo, checkout the files into the `sites-avalaible` dir, and include them on the `lms` and `cms` configs.

This doesn't work anymore, since we don't run ansible inside the customer VM anymore, so this change basically changes the file include on the Nginx configs, for variable include. 

To store these rules into the server-vars files isn't ideal, because it can get large, but in a second stage, we should move those variable contents to files, stored on edx-configs, and in ax, add the capability to include those files if they exists, so we don't rely on remember to include them.

We should get this merged as a mid term solution, since all (around 6) the customers that relies on this nginx rules, are in risk, because if some who isn't super familiar with the deploy, run the nginx playbook, could delete all the rules.