### PR TITLE
Adds custom domains support for tahoe

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -13,12 +13,20 @@
   become: True
   become_method: sudo
   gather_facts: True
+  vars:
+    appsembler_roles: "../../appsembler-roles"
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "4GB" }
     - role: sudo
+    - custom_domains # This gets the list of domains
+    - edx_ansible
+    - role: "{{ appsembler_roles }}/gcsfuse"
     - oraclejdk
     - elasticsearch
     - memcached
+    - { role: "{{ appsembler_roles }}/letsencrypt", letsencrypt_webserver: "" }
+    - role: "{{ appsembler_roles }}/cert_agent"
+
 
 - name: Configure app server instance(s)
   hosts: edx
@@ -26,6 +34,7 @@
   become_method: sudo
   gather_facts: True
   vars:
+    appsembler_roles: "../../appsembler-roles"
     migrate_db: "yes"
     openid_workaround: True
     EDXAPP_LMS_NGINX_PORT: '80'
@@ -37,6 +46,8 @@
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: sudo
+    - custom_domains # This gets a lits of custom domains
+    - role: "{{ appsembler_roles }}/gcsfuse"
     - mysql_init
     - role: nginx
       nginx_sites:
@@ -66,6 +77,7 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic
       when: COMMON_ENABLE_NEWRELIC
+    - { role: "{{ appsembler_roles }}/letsencrypt", letsencrypt_run: false }
 
 - name: Install xqueue, notifier and rabbitmq on services node
   hosts: "services"

--- a/playbooks/roles/custom_domains/meta/main.yml
+++ b/playbooks/roles/custom_domains/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - common_vars

--- a/playbooks/roles/custom_domains/tasks/main.yml
+++ b/playbooks/roles/custom_domains/tasks/main.yml
@@ -1,0 +1,36 @@
+- name: Include edxapp vars
+  include_vars:
+    file: ../../edxapp/defaults/main.yml
+  tags:
+    - custom_domains
+    - custom_domains:get_domains
+
+- name: "Fetch custom domains list"
+  become_user: "{{ edxapp_user }}"
+  django_manage: >
+    command="lms custom_domains_list"
+    app_path="{{ edxapp_code_dir }}"
+    settings=amc
+    pythonpath="{{ edxapp_code_dir }}"
+    virtualenv="{{ edxapp_venv_dir }}"
+  register: custom_domains_cmd
+  run_once: True
+  delegate_to: "{{ groups['edx'][0] }}"
+  tags:
+    - custom_domains
+    - custom_domains:get_domains
+
+- name: Set fact letsencrypt_certs
+  set_fact:
+    letsencrypt_certs: "{{ custom_domains_cmd.out|from_json }}"
+  tags:
+    - custom_domains
+    - custom_domains:get_domains
+
+- name: Print letsencrypt_certs
+  debug:
+    var: letsencrypt_certs
+  tags:
+    - custom_domains
+    - custom_domains:debug
+

--- a/playbooks/roles/edx_ansible/defaults/main.yml
+++ b/playbooks/roles/edx_ansible/defaults/main.yml
@@ -33,6 +33,9 @@ edx_ansible_debian_pkgs:
   - python-yaml
   - python-mysqldb
 
+appsembler_roles_version: "develop"
+appsembler_roles_source_repo: "https://github.com/appsembler/roles.git"
+appsembler_roles_code_dir: "{{ edx_ansible_app_dir }}/appsembler-roles"
 edx_ansible_app_dir: "{{ COMMON_APP_DIR }}/edx_ansible"
 edx_ansible_code_dir: "{{ edx_ansible_app_dir }}/edx_ansible"
 edx_ansible_data_dir: "{{ COMMON_DATA_DIR }}/edx_ansible"

--- a/playbooks/roles/edx_ansible/tasks/deploy.yml
+++ b/playbooks/roles/edx_ansible/tasks/deploy.yml
@@ -10,6 +10,17 @@
     - install
     - install:code
 
+- name: Git checkout appsembler_roles_source_repo repo into appsembler_roles_code_dir
+  git:
+    dest: "{{ appsembler_roles_code_dir }}"
+    repo: "{{ appsembler_roles_source_repo }}"
+    version: "{{ appsembler_roles_version }}"
+    accept_hostkey: yes
+  become_user: "{{ edx_ansible_user }}"
+  tags:
+    - install
+    - install:code
+
 - name: Install edx_ansible venv requirements
   pip:
     requirements: "{{ edx_ansible_requirements_file }}"
@@ -26,6 +37,30 @@
   template:
     dest: "{{ edx_ansible_app_dir}}/update"
     src: "update.j2"
+    owner: "{{ edx_ansible_user }}"
+    group: "{{ edx_ansible_user }}"
+    mode: "0755"
+  when: devstack is not defined or not devstack
+  tags:
+    - install
+    - install:configuration
+
+- name: Copy over inventory
+  template:
+    dest: "{{ edx_ansible_app_dir}}/app_nodes_inventory"
+    src: "app_nodes_inventory.j2"
+    owner: "{{ edx_ansible_user }}"
+    group: "{{ edx_ansible_user }}"
+    mode: "0755"
+  when: devstack is not defined or not devstack
+  tags:
+    - install
+    - install:configuration
+
+- name: Copy over redacted server-vars.yml
+  template:
+    dest: "{{ edx_ansible_app_dir}}/server-vars.yml"
+    src: "server_vars.j2"
     owner: "{{ edx_ansible_user }}"
     group: "{{ edx_ansible_user }}"
     mode: "0755"

--- a/playbooks/roles/edx_ansible/templates/app_nodes_inventory.j2
+++ b/playbooks/roles/edx_ansible/templates/app_nodes_inventory.j2
@@ -1,0 +1,5 @@
+[edx]
+{% for h in groups['edx'] %}
+{{ h }}
+{% endfor %}
+

--- a/playbooks/roles/edx_ansible/templates/server_vars.j2
+++ b/playbooks/roles/edx_ansible/templates/server_vars.j2
@@ -1,0 +1,26 @@
+# This file contains a redacted version of our edx-configs
+# server-vars.yml file with only the necessary variables for the
+# ANSIBLE_CMD command in cert_agent to be able to run.
+#
+# NOTE: Take care not to define any variables for which the defaults have
+# not been overwritten in edx-configs server-vars.yml because the templating
+# will fail otherwise
+
+# letsencrypt vars
+letsencrypt_email: "{{ letsencrypt_email }}"
+letsencrypt_run: true
+letsencrypt_webserver_sites_available: "{{ letsencrypt_webserver_sites_available }}"
+letsencrypt_https_redirect: "{{ letsencrypt_https_redirect }}"
+letsencrypt_webroot: "{{ letsencrypt_webroot }}"
+letsencrypt_webuser: "{{ letsencrypt_webuser }}"
+
+# Cert agent vars
+# TODO
+
+# NGINX stuff
+EDXAPP_LMS_NGINX_PORT: "{{ EDXAPP_LMS_NGINX_PORT }}"
+NGINX_ENABLE_SSL: "{{ NGINX_ENABLE_SSL }}"
+EDXAPP_LMS_SSL_NGINX_PORT: "{{ EDXAPP_LMS_SSL_NGINX_PORT }}"
+NGINX_REDIRECT_TO_HTTPS: "{{ NGINX_REDIRECT_TO_HTTPS }}"
+NGINX_SET_X_FORWARDED_HEADERS: "{{ NGINX_SET_X_FORWARDED_HEADERS }}"
+NGINX_ROBOT_RULES: "{{ NGINX_ROBOT_RULES }}"

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -14,6 +14,9 @@ nginx_lms_client_max_body_size: 4M
 nginx_cms_proxy_read_timeout: 60s
 nginx_lms_proxy_read_timeout: 60s
 
+NGINX_LMS_CUSTOM_DOMAINS: []
+NGINX_CMS_CUSTOM_DOMAINS: []
+
 NGINX_EDXAPP_EXTRA_SITES: []
 NGINX_EDXAPP_EXTRA_CONFIGS: []
 NGINX_EDXAPP_CUSTOM_REDIRECTS: {}

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -233,6 +233,65 @@
     - install
     - install:configuration
 
+# Custom domains
+# - name: Copy common settings for the LMS and CMS
+#   template:
+#     src: "edx/app/nginx/lms-common-settings.j2"
+#     dest: "{{ nginx_sites_available_dir }}/lms-common-settings"
+#     owner: root
+#     group: "{{ common_web_user }}"
+#     mode: 0640
+#   notify: reload nginx
+#   when: inventory_hostname in groups['edx']
+#   tags:
+#     - install
+#     - install:configuration
+#     - nginx:custom_domains
+
+# I thin this will be useful in the beginning so I'm leaving it here.
+# Remove when not necessary anymore.
+- name: Debug custom domains structure
+  debug: var=item
+  with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
+  when: inventory_hostname in groups['edx']
+  tags:
+    - nginx:custom_domains
+    - nginx:custom_domains:debug
+
+- name: Copy configs for LMS custom domains
+  template:
+    src: "edx/app/nginx/sites-available/lms-custom.j2"
+    dest: "{{ nginx_sites_available_dir }}/{{ item }}"
+    owner: root
+    group: "{{ common_web_user }}"
+    mode: 0640
+  with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
+  when: inventory_hostname in groups['edx']
+  notify: reload nginx
+  tags:
+    - install
+    - install:configuration
+    - nginx:custom_domains
+
+- name: Create nginx config links for custom domains
+  file:
+    src: "{{ nginx_sites_available_dir }}/{{ item }}"
+    dest: "{{ nginx_sites_enabled_dir }}/{{ item }}"
+    state: link
+    owner: root
+    group: root
+  with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
+  when: inventory_hostname in groups['edx']
+  notify: reload nginx
+  tags:
+    - install
+    - install:configuration
+    - nginx:custom_domains
+
+- name: Reload nginx for custom domains to take effect
+  service: name=nginx state=reloaded
+  tags: ['nginx:custom_domains']
+
   # These are static pages that can be used
   # for nginx rate limiting, 500 errors, etc.
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
@@ -1,0 +1,229 @@
+  # LMS configuration file for nginx, templated by ansible
+
+  {% if NGINX_EDXAPP_ENABLE_S3_MAINTENANCE %}
+
+  # Do not include a 502 error in NGINX_ERROR_PAGES when
+  # NGINX_EDXAPP_ENABLE_MAINTENANCE is enabled.
+
+  error_page 502 @maintenance;
+
+    {% include "s3_maintenance.j2" %}
+
+  {% endif %}
+
+  # error pages
+  {% for k, v in NGINX_EDXAPP_ERROR_PAGES.iteritems() %}
+error_page {{ k }} {{ v }};
+  {% endfor %}
+
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
+  {% if NGINX_HEALTH_CHECK_ENABLED %}
+  if ($healthcheck) {
+  return 200;
+  }
+  {% endif %}
+
+
+  # Nginx does not support nested condition or or conditions so
+  # there is an unfortunate mix of conditonals here.
+  {% if NGINX_REDIRECT_TO_HTTPS %}
+     {% if NGINX_HTTPS_REDIRECT_STRATEGY == "scheme" %}
+  # Redirect http to https over single instance
+  if ($scheme != "https")
+  {
+   set $do_redirect_to_https "true";
+  }
+
+     {% elif NGINX_HTTPS_REDIRECT_STRATEGY == "forward_for_proto" %}
+
+  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB
+  if ($http_x_forwarded_proto = "http")
+  {
+   set $do_redirect_to_https "true";
+  }
+     {% endif %}
+
+  # Execute the actual redirect
+  if ($do_redirect_to_https = "true")
+  {
+  return 301 https://$host$request_uri;
+  }
+  {% endif %}
+
+  access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
+  error_log {{ nginx_log_dir }}/error.log error;
+
+  # CS184 requires uploads of up to 4MB for submitting screenshots.
+  # CMS requires larger value for course assest, values provided
+  # via hiera.
+  client_max_body_size {{ nginx_lms_client_max_body_size }};
+  proxy_read_timeout {{ nginx_lms_proxy_read_timeout }};
+
+  rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
+
+  {% include "python_lib.zip.j2" %}
+  {% include "common-settings.j2" %}
+
+  {% if NGINX_EDXAPP_EMBARGO_CIDRS -%}
+  #only redirect to embargo when $embargo == true and $uri != $embargo_url
+  #this is a hack to do multiple conditionals
+  set $embargo_url "/embargo/blocked-message/courseware/embargo/";
+  if ( $embargo ) {
+    set $do_embargo "A";
+  }
+  if ( $uri != $embargo_url ) {
+    set $do_embargo "${do_embargo}B";
+  }
+  if ( $do_embargo = "AB" ) {
+    return 302 $embargo_url;
+  }
+  {% endif -%}
+
+  location @proxy_to_lms_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://lms-backend;
+  }
+
+  location / {
+    {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
+      {% include "basic-auth.j2" %}
+    {% endif %}
+
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # /login?next=<any image> can be used by 3rd party sites in <img> tags to
+  # determine whether a user on their site is logged into edX.
+  # The most common image to use is favicon.ico.
+  location /login {
+    {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
+      {% include "basic-auth.j2" %}
+    {% endif %}
+
+    if ( $arg_next ~* "favicon.ico" ) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_lms_app;
+  }
+
+{% if NGINX_EDXAPP_EMBARGO_CIDRS %}
+  location $embargo_url {
+    try_files $uri @proxy_to_lms_app;
+  }
+{% endif %}
+
+  # No basic auth for /segmentio/event
+  location /segmentio/event {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # The api is accessed using OAUTH2 which
+  # uses the authorization header so we can't have
+  # basic auth on it as well.
+  location /api {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # Need a separate location for the image uploads endpoint to limit upload sizes
+  location ~ ^/api/profile_images/[^/]*/[^/]*/upload$ {
+    try_files $uri @proxy_to_lms_app;
+    client_max_body_size {{ EDXAPP_PROFILE_IMAGE_MAX_BYTES + 1000 }};
+  }
+
+  location /notifier_api {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  location /user_api {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth security on the github_service_hook url, so that github can use it for cms
+  location /github_service_hook {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth security on oauth2 endpoint
+  location /oauth2 {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth security on third party auth endpoints
+  location /auth {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth security on assets
+  location /c4x {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  location /asset {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth security on the heartbeat url, so that ELB can use it
+  location /heartbeat {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth on the LTI provider endpoint, it does OAuth1
+  location /lti_provider {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth on LTI component grade.
+  location ~ /handler_noauth {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  location /courses {
+    {%- if EDXAPP_ENABLE_RATE_LIMITING -%}
+    # Set Limit
+    limit_req zone=cookies burst={{ EDXAPP_COURSES_REQUEST_BURST_RATE }};
+
+    {%- if EDXAPP_RATE_LIMITED_USER_AGENTS|length > 0 %}
+    limit_req zone=agents burst={{ EDXAPP_COURSES_USER_AGENT_BURST_RATE }};
+    {%- endif %}
+    error_page  503 = /server/rate-limit.html;
+    {%- endif -%}
+
+    {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
+      {%- include "basic-auth.j2" %}
+    {% endif %}
+    try_files $uri @proxy_to_lms_app;
+  }
+
+location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
+    root {{ edxapp_media_dir }};
+    try_files /$file =404;
+    expires {{ EDXAPP_PROFILE_IMAGE_MAX_AGE }}s;
+}
+
+  {% include "robots.j2" %}
+  {% include "static-files.j2" %}
+
+  {% include "extra_locations_lms.j2" ignore missing %}
+
+  {% if EDXAPP_XBLOCK_SETTINGS.get('ScormXBlock', False) %}
+    # asterisk needed so it doesn't break if the file doesn't exist
+    include {{nginx_app_dir}}/includes/scorm_extra_locations_lms*;
+  {% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-custom.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-custom.j2
@@ -1,0 +1,18 @@
+server {
+  server_name {{ item }};
+
+  listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} ssl;
+
+  ssl_certificate /etc/letsencrypt/live/{{ item }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ item }}/privkey.pem;
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+  location '/.well-known/acme-challenge' {
+    default_type "text/plain";
+    root {{ letsencrypt_webroot }};
+  }
+
+
+  {% include "lms-common-settings.j2" %}
+}


### PR DESCRIPTION
- Adds letsencrypt role
- Adds appsembler roles and inventory
- We require our own roles repo for the playbook to run.
  Especially if we're running "ansible-playbook --tags=letsencrypt:run ..."
  in an automated fashion.
- We also need a list of edx app nodes so we copy over a inventory file
  called "app_nodes_inventory" that lives in the "edx_ansible_app_dir".

- Putting that all together the calling command should be:

    "cd /edx/app/edx_ansible/edx_ansible/playbooks"
    "../../venvs/edx_ansible/bin/ansible-playbook -i ../../app_nodes_inventory --tags=letsencrypt:run
    amc.yml"

Or something similar depending on what we decide is best but we need to
take care to invoke the correct venv and to be careful with the paths.

- Adds cert_agent role
- Adds tag for getting list of custom domains
- Adds templated redacted server-vars file
  That we need for running the Ansible code on the services node locally

- Fixes custom_domains:get_domains
  When one registers the output of a django_manage command there is
  not "stdout" parameter like with normal commands but rather an "out"
  parameter.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
