### PR TITLE
Apply role tags in ficus playbooks

### DIFF
--- a/playbooks/appsemblerPlaybooks/ficus_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_basic.yml
@@ -19,10 +19,11 @@
     POSTGRESQL_AGGREGATION_INSTALL_CRON: true
     ENABLE_ECOMMERCE: false
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - { role: swapfile, SWAPFILE_SIZE: "4GB", tags: ['swapfile'] }
     - sudo
     - role: nginx
       nginx_sites: []
+      tags: ['nginx']
     - role: "{{ appsembler_roles }}/letsencrypt"
       when: letsencrypt_certs | length
     - role: nginx
@@ -34,36 +35,48 @@
       - edx_notes_api
       nginx_default_sites:
       - lms
-    - mysql
-    - mysql_init
+      tags: ['nginx']
+    - { role: mysql, tags: ['mysql'] }
+    - { role: mysql_init, tags: ['mysql_init'] }
     - role: memcache
       when: "'localhost' in ' '.join(EDXAPP_MEMCACHE)"
+      tags: ['memcache']
     - role: mongo_3_0
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
-    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
-    - { role: 'edxapp', celery_worker: True }
-    - edxapp
-    - notifier
+      tags: ['mongo_3_0']
+    - { role: rabbitmq, rabbitmq_ip: '127.0.0.1', tags: ['rabbitmq'] }
+    - { role: edxapp, celery_worker: True, tags: ['edxapp'] }
+    - { role: edxapp, tags: ['edxapp'] }
+    - { role: notifier, tags: ['notifier'] }
     - role: edx_notes_api
       when: "INSTALL_EDX_NOTES is defined and INSTALL_EDX_NOTES"
+      tags: ['edx_notes_api']
     - role: demo
       when: "INSTALL_DEMO_DATA"
+      tags: ['demo']
     - role: oauth_client_setup
       when: COMMON_ENABLE_OAUTH_CLIENT
-    - oraclejdk
+      tags: ['oauth_client_setup']
+    - { role: oraclejdk, tags: ['oraclejdk'] }
     - role: elasticsearch
       when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"
-    - forum
+      tags: ['elasticsearch']
+    - { role: forum, tags: ['forum'] }
     - role: postgresql_aggregation
       when: COMMON_ENVIRONMENT == "prod"
-    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
-    - { role: "xqueue", update_users: True }
+      tags: ['postgresql_aggregation']
+    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5", tags: ['notifier'] }
+    - { role: xqueue, update_users: True, tags: ['xqueue'] }
     - { role: backups, BACKUPS_MONGO: True, BACKUPS_MYSQL: True, when: COMMON_ENABLE_BACKUPS }
-    - role: "githubsshkeys"
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']
     - role: ecommerce
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce']
     - role: ecomworker
       when: ENABLE_ECOMMERCE
+      tags: ['ecomworker']
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce_theme']

--- a/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
@@ -15,22 +15,23 @@
     BACKUPS_MYSQL: False
     COMMON_ENABLE_BACKUPS: True
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
-    - mongo_3_0
+    - { role: swapfile, SWAPFILE_SIZE: "2GB", tags: ['swapfile'] }
+    - { role: mongo_3_0, tags: ['mongo_3_0'] }
     - backups
-    - role: "githubsshkeys"
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']
 
 - name: Configure instance for stateful services
   hosts: services-server
   sudo: True
   gather_facts: True
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - { role: swapfile, SWAPFILE_SIZE: "4GB", tags: ['swapfile'] }
     - sudo
-    - oraclejdk
-    - elasticsearch
-    - memcached
+    - { role: oraclejdk, tags: ['oraclejdk'] }
+    - { role: elasticsearch, tags: ['elasticsearch'] }
+    - { role: memcached, tags: ['memcached'] }
 
 - name: Configure stateless edxapp instances
   hosts: edxapp-server
@@ -52,11 +53,12 @@
       when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
       tags: always
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - { role: swapfile, SWAPFILE_SIZE: "4GB", tags: ['swapfile'] }
     - sudo
-    - mysql_init
+    - { role: mysql_init, tags: ['mysql_init'] }
     - role: nginx
       nginx_sites: []
+      tags: ['nginx']
     - role: "{{ appsembler_roles }}/gcsfuse"
       when: "cloud_provider == 'gcp'"
     - role: "{{ appsembler_roles }}/letsencrypt"
@@ -68,22 +70,29 @@
       - forum
       nginx_default_sites:
       - lms
-    - { role: 'edxapp', celery_worker: True }
-    - edxapp
+      tags: ['nginx']
+    - { role: edxapp, celery_worker: True, tags: ['edxapp'] }
+    - { role: edxapp, tags: ['edxapp'] }
     - role: edx_notes_api
       when: "INSTALL_EDX_NOTES is defined and INSTALL_EDX_NOTES"
+      tags: ['edx_notes_api']
     - role: demo
       when: "INSTALL_DEMO_DATA"
-    - oauth_client_setup
-    - forum
-    - role: "githubsshkeys"
+      tags: ['demo']
+    - { role: oauth_client_setup, tags: ['oauth_client_setup'] }
+    - { role: forum, tags: ['forum'] }
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']
     - role: ecommerce
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce']
     - role: ecomworker
       when: ENABLE_ECOMMERCE
+      tags: ['ecomworker']
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce_theme']
 
 - name: Install xqueue, notifier and rabbitmq on services instance
   hosts: services-server
@@ -92,17 +101,19 @@
   vars:
     migrate_db: "yes"
   roles:
-    - edxapp_common
-    - mysql_init
+    - { role: edxapp_common, tags: ['edxapp_common'] }
+    - { role: mysql_init, tags: ['mysql_init'] }
     - role: nginx
       nginx_sites:
       - xqueue
-    - { role: 'rabbitmq', rabbitmq_ip: '0.0.0.0' }
-    - notifier
-    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
-    - { role: "xqueue", update_users: True }
-    - role: "githubsshkeys"
+      tags: ['nginx']
+    - { role: rabbitmq, rabbitmq_ip: '0.0.0.0', tags: ['rabbitmq'] }
+    - { role: notifier, tags: ['notifier'] }
+    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5", tags: ['notifier'] }
+    - { role: xqueue, update_users: True, tags: ['xqueue'] }
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']
 
 - name: Install Scampersand Reporting
   hosts: "edxapp-server-0"
@@ -113,6 +124,7 @@
   roles:
     - role: postgresql_aggregation
       when: COMMON_ENVIRONMENT == "prod"
+      tags: ['postgresql_aggregation']
 
 - name: Install Scampersand Reporting
   hosts: "edxapp-server-1"
@@ -123,3 +135,4 @@
   roles:
     - role: postgresql_aggregation
       when: COMMON_ENVIRONMENT == "prod"
+      tags: ['postgresql_aggregation']

--- a/playbooks/appsemblerPlaybooks/ficus_insights.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_insights.yml
@@ -12,15 +12,16 @@
     ELASTICSEARCH_VERSION: "1.5.2"
   roles:
     - sudo
-    - aws
-    - mysql_init
-    - memcache
-    - elasticsearch
-    - analytics_api
-    - analytics_pipeline
-    - insights
+    - { role: aws, tags: ['aws'] }
+    - { role: mysql_init, tags: ['mysql_init'] }
+    - { role: memcache, tags: ['memcache'] }
+    - { role: elasticsearch, tags: ['elasticsearch'] }
+    - { role: analytics_api, tags: ['analytics_api'] }
+    - { role: analytics_pipeline, tags: ['analytics_pipeline'] }
+    - { role: insights, tags: ['insights'] }
     - role: nginx
       nginx_sites:
         - insights
-    - insights_tracking_logs_sync
-    - setup_pipeline
+      tags: ['nginx']
+    - { role: insights_tracking_logs_sync, tags: ['insights_tracking_logs_sync'] }
+    - { role: setup_pipeline, tags: ['setup_pipeline'] }

--- a/playbooks/appsemblerPlaybooks/ficus_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_pro.yml
@@ -15,13 +15,13 @@
     BACKUPS_MYSQL: no
     COMMON_ENABLE_BACKUPS: True
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+    - { role: swapfile, SWAPFILE_SIZE: "2GB", tags: ['swapfile'] }
     - sudo
-    - edxapp_common
-    - mongo_3_0
-    - oraclejdk
-    - elasticsearch
-    - memcached
+    - { role: edxapp_common, tags: ['edxapp_common'] }
+    - { role: mongo_3_0, tags: ['mongo_3_0'] }
+    - { role: oraclejdk, tags: ['oraclejdk'] }
+    - { role: elasticsearch, tags: ['elasticsearch'] }
+    - { role: memcached, tags: ['memcached'] }
     - backups
 
 - name: Configure stateless edxapp instance
@@ -42,12 +42,13 @@
       when: EDXAPP_MONGO_USE_SSL is defined and EDXAPP_MONGO_USE_SSL
       tags: always
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "4GB" }
+    - { role: swapfile, SWAPFILE_SIZE: "4GB", tags: ['swapfile'] }
     - sudo
-    - edxapp_common
-    - mysql_init
+    - { role: edxapp_common, tags: ['edxapp_common'] }
+    - { role: mysql_init, tags: ['mysql_init'] }
     - role: nginx
       nginx_sites: []
+      tags: ['nginx']
     - role: "{{ appsembler_roles }}/letsencrypt"
       when: letsencrypt_certs | length
     - role: nginx
@@ -57,24 +58,32 @@
       - forum
       nginx_default_sites:
       - lms
-    - { role: 'edxapp', celery_worker: True }
-    - edxapp
+      tags: ['nginx']
+    - { role: edxapp, celery_worker: True, tags: ['edxapp'] }
+    - { role: edxapp, tags: ['edxapp'] }
     - role: edx_notes_api
       when: "INSTALL_EDX_NOTES is defined and INSTALL_EDX_NOTES"
+      tags: ['edx_notes_api']
     - role: demo
       when: "INSTALL_DEMO_DATA"
-    - oauth_client_setup
-    - forum
-    - role: "githubsshkeys"
+      tags: ['demo']
+    - { role: oauth_client_setup, tags: ['oauth_client_setup'] }
+    - { role: forum, tags: ['forum'] }
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']
     - role: postgresql_aggregation
       when: COMMON_ENVIRONMENT == "prod"
+      tags: ['postgresql_aggregation']
     - role: ecommerce
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce']
     - role: ecomworker
       when: ENABLE_ECOMMERCE
+      tags: ['ecomworker']
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
+      tags: ['ecommerce_theme']
 
 - name: Install xqueue, notifier and rabbitmq
   hosts: mongo-server
@@ -83,13 +92,15 @@
   vars:
     migrate_db: "yes"
   roles:
-    - mysql_init
+    - { role: mysql_init, tags: ['mysql_init'] }
     - role: nginx
       nginx_sites:
       - xqueue
-    - { role: 'rabbitmq', rabbitmq_ip: '0.0.0.0' }
-    - notifier
-    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
-    - { role: "xqueue", update_users: True }
-    - role: "githubsshkeys"
+      tags: ['nginx']
+    - { role: rabbitmq, rabbitmq_ip: '0.0.0.0', tags: ['rabbitmq'] }
+    - { role: notifier, tags: ['notifier'] }
+    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5", tags: ['notifier'] }
+    - { role: xqueue, update_users: True, tags: ['xqueue'] }
+    - role: githubsshkeys
       when: "cloud_provider == 'azure'"
+      tags: ['githubsshkeys']


### PR DESCRIPTION
This PR adds tags to each role in the ficus playbooks. When a tag is applied to a role in a playbook, the tag is [inherited](https://docs.ansible.com/ansible/latest/playbooks_tags.html#tag-inheritance) by all tasks in that role and its dependencies.

For example, to run only the `xqueue` role and its dependencies, run

```
$ ansible-playbook -i path/to/inventory --tags xqueue ficus_pro.yml
```

You can check which tasks will be run for a tag using `--list-tasks`:

```
$ ansible-playbook -i path/to/inventory --list-tasks --tags xqueue ficus_pro.yml
```