### PR TITLE
multiple edxapp Site themes

### DIFF
--- a/playbooks/appsemblerPlaybooks/update_theme.yml
+++ b/playbooks/appsemblerPlaybooks/update_theme.yml
@@ -64,33 +64,7 @@
         - install:code
         - update_lms_theme
 
-    - name: checkout comprehensive theme
-      git:
-        dest: "{{ edxapp_theme_dir }}/{{ EDXAPP_DEFAULT_SITE_THEME }}"
-        repo: "{{ edxapp_theme_source_repo }}"
-        version: "{{ edxapp_theme_version }}"
-        accept_hostkey: yes
-      when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true and EDXAPP_DEFAULT_SITE_THEME != ''
-      become_user: "{{ edxapp_user }}"
-      environment:
-        GIT_SSH: "{{ edxapp_git_ssh }}"
-      register: edxapp_theme_checkout
-      tags:
-        - install
-        - install:code
-        - update_lms_theme
-
-    - name: checkout customer override theme
-      git:
-        dest: "{{ edxapp_theme_dir }}/{{ EDXAPP_DEFAULT_SITE_THEME }}/customer_specific"
-        repo: "{{ edxapp_customer_theme_source_repo }}"
-        version: "{{ edxapp_customer_theme_version }}"
-        accept_hostkey: yes
-        key_file: "/edx/app/edxapp/.ssh/id_rsa"
-      when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true and edxapp_customer_theme_source_repo != ''
-      become_user: "{{ edxapp_user }}"
-      environment:
-        GIT_SSH: "{{ edxapp_git_ssh }}"
+    - include: ../roles/edxapp/tasks/customer_theme.yml
       tags:
         - install
         - install:code

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -663,6 +663,23 @@ EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO: ""
 # EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO
 EDXAPP_COMPREHENSIVE_THEME_VERSION: ""
 
+# supply a default site theme keyed to the main LMS domain
+# only works with EDXAPP_ENABLE_COMPREHENSIVE_THEMING set to true, 
+# otherwise, ignored -
+# have to use this way of defining dict in string format
+# so the variable is interpolated in the key, but if not
+# using variable key names a more standard format can be used
+EDXAPP_SITE_THEMES: "{
+    '{{ EDXAPP_LMS_SITE_NAME }}': {
+      'theme_name': '{{ EDXAPP_DEFAULT_SITE_THEME | default(\'edx-theme-codebase\', true) }}',
+      'theme_source_repo': '{{ edxapp_theme_source_repo | default(\'git@github.com:appsembler/edx-theme-codebase.git\', true) }}',
+      'theme_version': '{{ edxapp_theme_version | default(\'master\', true) }}',
+      'customer_theme_source_repo': '{{ edxapp_customer_theme_source_repo | default(\'https://github.com/appsembler/edx-theme-customers.git\', true) }}',
+      'customer_theme_version': '{{ edxapp_customer_theme_version | default(\'\', true) }}'
+    }
+  }
+  "
+
 # SAML KEYS
 EDXAPP_SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''
 EDXAPP_SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: ''

--- a/playbooks/roles/edxapp/tasks/customer_theme.yml
+++ b/playbooks/roles/edxapp/tasks/customer_theme.yml
@@ -15,7 +15,6 @@
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
-  notify: recompile SASS
   register: edxapp_theme_checkout
 
 - name: checkout customer override themes
@@ -30,5 +29,4 @@
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
-  notify: recompile SASS
   register: edxapp_theme_override_checkout

--- a/playbooks/roles/edxapp/tasks/customer_theme.yml
+++ b/playbooks/roles/edxapp/tasks/customer_theme.yml
@@ -1,34 +1,34 @@
 ---
 
-- name: checkout comprehensive theme
+- debug: msg="Checking out site theme {{item}}"
+  with_dict: "{{EDXAPP_SITE_THEMES}}"
+  tags: debug
+
+- name: checkout comprehensive themes
   git:
-    dest: "{{ edxapp_theme_dir }}/{{ EDXAPP_DEFAULT_SITE_THEME }}"
-    repo: "{{ edxapp_theme_source_repo }}"
-    version: "{{ edxapp_theme_version }}"
+    dest: "{{ edxapp_theme_dir }}/{{ item.value.theme_name }}"
+    repo: "{{ item.value.theme_source_repo }}"
+    version: "{{ item.value.theme_version }}"
     accept_hostkey: yes
-  when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true and EDXAPP_DEFAULT_SITE_THEME != ''
+  with_dict: "{{EDXAPP_SITE_THEMES}}"
+  when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
   notify: recompile SASS
   register: edxapp_theme_checkout
-  tags:
-    - install
-    - install:code
 
-- name: checkout customer override theme
+- name: checkout customer override themes
   git:
-    dest: "{{ edxapp_theme_dir }}/{{ EDXAPP_DEFAULT_SITE_THEME }}/customer_specific"
-    repo: "{{ edxapp_customer_theme_source_repo }}"
-    version: "{{ edxapp_customer_theme_version }}"
+    dest: "{{ edxapp_theme_dir }}/{{ item.value.theme_name }}/customer_specific"
+    repo: "{{ item.value.customer_theme_source_repo }}"
+    version: "{{ item.value.customer_theme_version }}"
     accept_hostkey: yes
     key_file: "/edx/app/edxapp/.ssh/id_rsa"
-  when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true and edxapp_customer_theme_source_repo != ''
+  with_dict: "{{EDXAPP_SITE_THEMES}}"
+  when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING == true and item.value.customer_theme_version and item.value.customer_theme_source_repo
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
   notify: recompile SASS
   register: edxapp_theme_override_checkout
-  tags:
-    - install
-    - install:code

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -81,7 +81,7 @@
     repo: "{{ edxapp_theme_source_repo }}"
     version: "{{ edxapp_theme_version }}"
     accept_hostkey: yes
-  when: edxapp_theme_name != ''
+  when: edxapp_theme_name and not EDXAPP_ENABLE_COMPREHENSIVE_THEMING
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
@@ -91,6 +91,10 @@
     - install:code
 
 - include: customer_theme.yml
+  tags:
+    - install
+    - install:code
+    - update_lms_theme
 
 - name: Stat each requirements file with Github URLs to ensure it exists
   stat:


### PR DESCRIPTION
use EDXAPP_SITE_THEMES hash to support multiple base/customer themes for Sites

default is defined which will use values from older-style
theme definitions using EDXAPP_DEFAULT_SITE_THEME,
EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO, and
EDXAPP_COMPREHENSIVE_THEME_VERSION variables.
EDXAPP_SITE_THEMES won't do anything unless comprehensive theming
is enabled

This brings feature from Eucalyptus into Ficus, and also has some DRY changes in `update_theme.yml` and `customer_theme.yml` files

Soon I will be updating base settings files in `edx-configs` to make use of this feature... in the mean time, for an example see Trinity example at https://github.com/noderabbit-team/edx-configs/blob/master/trinity/prod/files/server-vars.yml#L238-L262