### PR TITLE
Separate default_site option for http and https sites

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -46,7 +46,7 @@
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: sudo
-    - custom_domains # This gets a lits of custom domains
+    - custom_domains # This gets a list of custom domains
     - role: "{{ appsembler_roles }}/gcsfuse"
     - mysql_init
     - role: nginx

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -14,6 +14,7 @@ nginx_lms_client_max_body_size: 4M
 nginx_cms_proxy_read_timeout: 60s
 nginx_lms_proxy_read_timeout: 60s
 
+nginx_enable_custom_domains: false
 NGINX_LMS_CUSTOM_DOMAINS: []
 NGINX_CMS_CUSTOM_DOMAINS: []
 

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -253,7 +253,7 @@
 - name: Debug custom domains structure
   debug: var=item
   with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
-  when: inventory_hostname in groups['edx']
+  when: nginx_enable_custom_domains and inventory_hostname in groups['edx']
   tags:
     - nginx:custom_domains
     - nginx:custom_domains:debug
@@ -266,7 +266,7 @@
     group: "{{ common_web_user }}"
     mode: 0640
   with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
-  when: inventory_hostname in groups['edx']
+  when: nginx_enable_custom_domains and inventory_hostname in groups['edx']
   notify: reload nginx
   tags:
     - install
@@ -281,7 +281,7 @@
     owner: root
     group: root
   with_items: "{{ letsencrypt_certs|json_query('[*].domains') }}"
-  when: inventory_hostname in groups['edx']
+  when: nginx_enable_custom_domains and inventory_hostname in groups['edx']
   notify: reload nginx
   tags:
     - install

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -1,7 +1,13 @@
-{%- if "lms" in nginx_default_sites -%}
+{%- if "lms" in nginx_default_sites and "letsencrypt" not in nginx_default_sites -%}
   {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
+{%- endif -%}
+
+{%- if "lms" in nginx_default_sites -%}
+  {%- set default_ssl_site = "default_server" -%}
+{%- else -%}
+  {%- set default_ssl_site = "" -%}
 {%- endif -%}
 
 {% if NGINX_HEALTH_CHECK_ENABLED %}
@@ -109,7 +115,7 @@ error_page {{ k }} {{ v }};
   listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
 
   {% if NGINX_ENABLE_SSL %}
-  listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_ssl_site }} ssl;
 
   ssl_certificate {{ NGINX_SSL_CERTIFICATE_PATH }};
   ssl_certificate_key {{ NGINX_SSL_KEY_PATH }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -1,4 +1,4 @@
-{%- if "lms" in nginx_default_sites and "letsencrypt" not in nginx_default_sites -%}
+{%- if "lms" in nginx_default_sites and not nginx_enable_custom_domains -%}
   {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}


### PR DESCRIPTION
Needed because let’s encrypt requires default_site on http if present. It seems to me that this doesn't break previous customer deployments, but allows correct behavior if both `lms`
 and `letsencrypt` are specified in `nginx_default_sites`.

Also, this PR is paired with the PR on the roles repo: https://github.com/appsembler/roles/pull/20

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
