### PR TITLE
Fix backup.py issue with boto in Azure instances

### DIFF
--- a/playbooks/roles/backups/defaults/main.yml
+++ b/playbooks/roles/backups/defaults/main.yml
@@ -7,6 +7,7 @@ BACKUPS_MONGO_PASSWORD: 'password'
 BACKUPS_BUCKET: ''
 BACKUPS_DIR: '/tmp/db_backups'
 BACKUPS_SENTRY_DSN: ''
+BACKUPS_RUN_DURING_DEPLOYMENT: yes
 
 # gs: Google Cloud Storage
 # s3: Amazon Simple Storage Service

--- a/playbooks/roles/backups/files/backup.py
+++ b/playbooks/roles/backups/files/backup.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import time
 
-import boto
 import raven
 
 
@@ -37,6 +36,7 @@ def upload_to_s3(file_path, bucket, aws_access_key_id, aws_secret_access_key):
     """
 
     from filechunkio import FileChunkIO
+    import boto
 
     logging.info('Uploading backup at "{}" to Amazon S3 bucket "{}"'
                  .format(file_path, bucket))
@@ -73,7 +73,7 @@ def upload_to_gcloud_storage(file_path, bucket):
         bucket: The name of a Google Cloud Storage bucket.
     """
 
-    import gcs_oauth2_boto_plugin
+    import boto
 
     logging.info('Uploading backup at "{}" to Google Cloud Storage bucket '
                  '"{}"'.format(file_path, bucket))

--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -16,7 +16,7 @@
   with_items:
     - {name: gcs-oauth2-boto-plugin, version: 1.9}
     - {name: oauth2client, version: 1.5.2}
-    - {name: pyopenssl, version: 0.15.1}
+    - {name: pyopenssl, version: 16.2.0}
     - {name: cryptography, version: 1.4}
   when: BACKUPS_PROVIDER == 'gs'
   tags: ['backups']
@@ -30,7 +30,7 @@
   pip: name={{ item.name }} version={{ item.version }}
   with_items:
     - {name: azure-storage, version: 0.33.0}
-    - {name: pyopenssl, version: 0.15.1}
+    - {name: pyopenssl, version: 16.2.0}
   when: BACKUPS_PROVIDER == 'azure'
   tags: ['backups']
 

--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -110,3 +110,28 @@
     BACKUP_SENTRY_DSN: '{{ BACKUPS_SENTRY_DSN }}'
   when: BACKUPS_MYSQL and "{{ item.value }}" != ""
   tags: ['backups']
+
+- name: Run a backup for mysql/mongodb to make sure it works
+  become: yes
+  become_user: root
+  shell: /usr/local/bin/edx_backup {{ item.service }}
+  environment:
+    BACKUP_DIR: '{{ BACKUPS_DIR }}'
+    BACKUP_BUCKET: '{{ BACKUPS_BUCKET }}'
+    BACKUP_PROVIDER: '{{ BACKUPS_PROVIDER }}'
+    BACKUP_AWS_ACCESS_KEY_ID: '{{ BACKUPS_AWS_ACCESS_KEY_ID }}'
+    BACKUP_AWS_SECRET_ACCESS_KEY: '{{ BACKUPS_AWS_SECRET_ACCESS_KEY }}'
+    BACKUP_AZURE_STORAGE_ACCOUNT: '{{ BACKUPS_AZURE_STORAGE_ACCOUNT }}'
+    BACKUP_AZURE_STORAGE_KEY: '{{ BACKUPS_AZURE_STORAGE_KEY }}'
+    BACKUP_SENTRY_DSN: '{{ BACKUPS_SENTRY_DSN }}'
+    BACKUP_USER: '{{ BACKUPS_MONGO_USER }}'
+    BACKUP_PASSWORD: '{{ BACKUPS_MONGO_PASSWORD }}'
+  when:
+    - BACKUPS_RUN_DURING_DEPLOYMENT
+    - item.enabled
+  with_items:
+    - service: mongodb
+      enabled: "{{ BACKUPS_MONGO }}"
+    - service: mysql
+      enabled: "{{ BACKUPS_MYSQL }}"
+  tags: ['backups']


### PR DESCRIPTION
Since boto isn't installed by default in Azure instances, `backup.py` used to break. This should fix it!

### TODO
 - [x] Check it on an instance to see if works!