### PR TITLE
Nginx redirect 502,504 errors to new server-maintenance.html page

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -84,6 +84,11 @@ NGINX_SERVER_HTML_FILES:
     msg: 'We have been notified of the error, if it persists please let us know at <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     heading: 'Uh oh, we are having some server issues..'
+  - file: server-maintenance.html
+    title: '{{ EDXAPP_PLATFORM_NAME }} temporarily unavailable'
+    msg: 'A maintenance operation is currently in progress on our system that will affect your access to our online courses.<br/><br/>If you have any questions or concerns, please contact <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
+    img: "{{ NGINX_SERVER_ERROR_IMG }}"
+    heading: 'Maintenance in Progress'
 
 NGINX_APT_REPO: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 
@@ -103,10 +108,12 @@ nginx_debian_pkgs:
 
 NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False
 nginx_default_error_page: "/server/server-error.html"
+nginx_maintenance_page: "/server/server-maintenance.html"
 NGINX_EDXAPP_ERROR_PAGES:
   "500": "{{ nginx_default_error_page }}"
   "502": "{{ nginx_default_error_page }}"
   "504": "{{ nginx_default_error_page }}"
+  "503": "{{ nginx_maintenance_page }}"
 
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 ECOMMERCE_HOSTNAME: '~^((stage|prod)-)?ecommerce.*'


### PR DESCRIPTION
Make a new `server-maintenance.html` page and redirect 502, 504 errors (gateway timeout, connection refused) errors to it, rather than showing default server error page.

