### PR TITLE
Add needed var to custom domains server-vars.yml file

### DIFF
--- a/playbooks/roles/edx_ansible/templates/server_vars.j2
+++ b/playbooks/roles/edx_ansible/templates/server_vars.j2
@@ -7,6 +7,7 @@
 # will fail otherwise
 
 # letsencrypt vars
+nginx_enable_custom_domains: "{{ nginx_enable_custom_domains }}"
 letsencrypt_email: "{{ letsencrypt_email }}"
 letsencrypt_run: true
 letsencrypt_webserver_sites_available: "{{ letsencrypt_webserver_sites_available }}"


### PR DESCRIPTION
Adds a necessary variable (for Tahoe custom domains to work) to the server-vars.yml that's generated on the services node where the letsencrypt playbook is being run. Without this, the [proper nginx configs](https://github.com/appsembler/configuration/blob/appsembler/ficus/master/playbooks/roles/nginx/tasks/main.yml#L256) don't get copied and the custom domain doesn't work.

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
