### PR TITLE
Fix themes file owner on update_theme.yml

### DIFF
--- a/playbooks/appsemblerPlaybooks/update_theme.yml
+++ b/playbooks/appsemblerPlaybooks/update_theme.yml
@@ -94,6 +94,18 @@
         - install:code
         - update_lms_theme
 
+    # TODO: Probably should figure out why it was broken in the first place? But it's not really a big deal.
+    - name: Fix the theme file owner after git checkout
+      file:
+        dest: "{{ item }}"
+        owner: "{{ edxapp_user }}"
+        group: "{{ edxapp_user }}"
+        state: directory  # to make recurse work
+        recurse: yes
+      with_items:
+        - "{{ edxapp_theme_dir }}"  # Comprehensive theme
+        - "{{ edxapp_app_dir }}/themes/"  # Stanford style-theme
+
     - name: remove read-only ssh key
       file:
         path: "{{ edxapp_git_identity }}"

--- a/playbooks/appsemblerPlaybooks/update_theme.yml
+++ b/playbooks/appsemblerPlaybooks/update_theme.yml
@@ -10,8 +10,6 @@
   - roles/common_vars/defaults/main.yml
   - roles/supervisor/defaults/main.yml
   - roles/edxapp/defaults/main.yml
-  vars:
-    tmp: none
   tasks:
     - name: Allow user running the playbook to sudo as other users
       lineinfile: >


### PR DESCRIPTION
This is not the best solution in earth. But l suspect that `become_user` is not getting activated either because Ansible bug or old Ansible being used.

Although it's a bit technically rude to fix a bug that I can't reproduce, the new step should be enough to fix it.

Closes #114