### PR TITLE
Refactor EDXAPP_SITE_THEMES variable

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -664,21 +664,20 @@ EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO: ""
 EDXAPP_COMPREHENSIVE_THEME_VERSION: ""
 
 # supply a default site theme keyed to the main LMS domain
-# only works with EDXAPP_ENABLE_COMPREHENSIVE_THEMING set to true, 
+# only works with EDXAPP_ENABLE_COMPREHENSIVE_THEMING set to true,
 # otherwise, ignored -
 # have to use this way of defining dict in string format
 # so the variable is interpolated in the key, but if not
 # using variable key names a more standard format can be used
 EDXAPP_SITE_THEMES: "{
     '{{ EDXAPP_LMS_SITE_NAME }}': {
-      'theme_name': '{{ EDXAPP_DEFAULT_SITE_THEME | default(\'edx-theme-codebase\', true) }}',
-      'theme_source_repo': '{{ edxapp_theme_source_repo | default(\'git@github.com:appsembler/edx-theme-codebase.git\', true) }}',
-      'theme_version': '{{ edxapp_theme_version | default(\'master\', true) }}',
-      'customer_theme_source_repo': '{{ edxapp_customer_theme_source_repo | default(\'https://github.com/appsembler/edx-theme-customers.git\', true) }}',
-      'customer_theme_version': '{{ edxapp_customer_theme_version | default(\'\', true) }}'
+      'theme_name': '{{ EDXAPP_DEFAULT_SITE_THEME | default(\"edx-theme-codebase\", true) }}',
+      'theme_source_repo': '{{ edxapp_theme_source_repo | default(\"git@github.com:appsembler/edx-theme-codebase.git\", true) }}',
+      'theme_version': '{{ edxapp_theme_version | default(\"master\", true) }}',
+      'customer_theme_source_repo': '{{ edxapp_customer_theme_source_repo | default(\"https://github.com/appsembler/edx-theme-customers.git\", true) }}',
+      'customer_theme_version': '{{ edxapp_customer_theme_version | default(\"\", true) }}'
     }
-  }
-  "
+  }"
 
 # SAML KEYS
 EDXAPP_SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''


### PR DESCRIPTION
This is a follow up on #109 because single quotes didn't work for me and kept throwing the error that Amir also reported. I've tested the PR and it works fine with EasyCare.

```
$ ax ansible --ansible-playbook=appsemblerPlaybooks/update_theme.yml provision; beep
WARN: Consider enabling `--include-base-vars` to skim the server-vars.yml

The error appears to have been in '/home/omar/work/appsembler/configuration/playbooks/appsemblerPlaybooks/roles/edxapp/defaults/main.yml': line 674, column 62, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    '{{ EDXAPP_LMS_SITE_NAME }}': {
      'theme_name': '{{ EDXAPP_DEFAULT_SITE_THEME | default(\'edx-theme-codebase\', true) }}',
                                                             ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"
```