### PR TITLE
Added tags to run git identity file tasks when running tag 'install:app-requirements'

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -37,6 +37,7 @@
     - install
     - install:base
     - deploy:platform
+    - install:app-requirements
 
 - name: set git fetch.prune to ignore deleted remote refs
   shell: git config --global fetch.prune true
@@ -345,6 +346,7 @@
   tags:
     - install
     - install:code
+    - isntall:app-requirements
 
 # creates the supervisor jobs for the
 # service variants configured, runs
@@ -414,6 +416,7 @@
     - install:configuration
     - install:code
     - deploy:platform
+    - install:app-requirements
 
 - include: tag_ec2.yml tags=deploy
   when: COMMON_TAG_EC2_INSTANCE


### PR DESCRIPTION
Amir tried to up a customer using the `install:app-requirements` tag and it failed to update the private_requirements packages because the deployment didn't create the `edxapp-git-identify` file.

This PR adds `install:app-requirements` to the tasks that creates and deletes `edxapp-git-identity`

 I tested it on piglet and it seems to work, but I do have concerns that some tasks may not get run, like migrations and restarting apps. Also, looks like `install:app-requirements` does not rebuild assets. Some updates will require asset compilation, which as a manual step can be easily forgotten
