### PR TITLE
Restart edxapp after edxapp_cfg update

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -426,6 +426,10 @@
 
 - set_fact:
     edxapp_installed: true
+  tags:
+    - manage
+    - deploy:platform
+    - edxapp_cfg
 
 ## Appsembler custom:
 ## compile i18n messages each time
@@ -445,6 +449,7 @@
   tags:
     - manage
     - deploy:platform
+    - edxapp_cfg
 
 - name: restart edxapp_workers
   supervisorctl:
@@ -457,6 +462,7 @@
   tags:
     - manage
     - deploy:platform
+    - edxapp_cfg
 
 - name: Create OAuth credentials
   shell: >


### PR DESCRIPTION
No need for manual SSH and restart the server.

Instead you'd run:

```
$ ax ansible --ansible-tag=edxapp_cfg provision
```

# TODO
 - [ ] Someone please run this to make sure it works first.