### PR TITLE
add the option to specify a diferent path for Acme challenge in Nginx config

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-custom.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-custom.j2
@@ -10,7 +10,11 @@ server {
 
   location '/.well-known/acme-challenge' {
     default_type "text/plain";
-    root {{ letsencrypt_webroot }};
+    {% if letsencrypt_alternative_acme_folder == "" %}
+      root {{ letsencrypt_webroot }};
+    {% else %}
+      alias {{ letsencrypt_webroot }}/{{ letsencrypt_alternative_acme_folder }};
+    {% endif %}
   }
 
 


### PR DESCRIPTION
For more information please refer to https://github.com/appsembler/roles/pull/32

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
