### PR TITLE
Sync SCORM files to S3 little by little to avoid out of memory errors

### DIFF
--- a/playbooks/roles/scorm/defaults/main.yml
+++ b/playbooks/roles/scorm/defaults/main.yml
@@ -3,7 +3,9 @@
 SCORM_S3_BACKUP: false
 # If there are any issues with the s3 sync an error
 # log will be sent to the following address.
-# This relies on your server being able to send mail
+# This relies on your server being able to send mail.  Set to 
+# true if it can
+SCORM_S3_LOGS_NOTIFY: false
 SCORM_S3_LOGS_NOTIFY_EMAIL: dummy@example.com
 SCORM_S3_LOGS_FROM_EMAIL: dummy@example.com
 

--- a/playbooks/roles/scorm/templates/sync-scorm-content-to-s3.j2
+++ b/playbooks/roles/scorm/templates/sync-scorm-content-to-s3.j2
@@ -48,7 +48,7 @@ done
 
 # If there are any errors from this point
 # send mail to {{ SCORM_S3_LOGS_NOTIFY_EMAIL }}
-
+{% if SCORM_S3_LOGS_NOTIFY %}
 onerror() {
   if [[ -z $noop ]]; then
     subj="Error syncing SCORM content to S3 bucket $bucket_name"
@@ -61,5 +61,11 @@ onerror() {
 }
 
 trap onerror ERR SIGHUP SIGINT SIGTERM
+{% endif %}
 
-s3cmd sync -c {{ scorm_dirs.home.path }}/.s3cfg $noop {{ scorm_asset_local_storage_path }}/ "s3://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}/scorms/" >>{{scorm_s3_sync_logfile}} 2>&1
+
+# trying to sync an entire large directory structure can use too much memory:
+# note that this won't sync folders on s3 but not in local storage back to local storage
+for SCORM_DIR in $(ls -d {{ scorm_asset_local_storage_path }}/*); do
+  s3cmd sync -c {{ scorm_dirs.home.path }}/.s3cfg $noop $SCORM_DIR/ "s3://{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}/scorms/`basedir $SCORM_DIR`/" >>{{scorm_s3_sync_logfile}} 2>&1
+done

--- a/playbooks/roles/scorm/templates/sync-scorm-content-to-s3.j2
+++ b/playbooks/roles/scorm/templates/sync-scorm-content-to-s3.j2
@@ -46,9 +46,9 @@ while getopts "vhnb:d:" opt; do
   esac
 done
 
+{% if SCORM_S3_LOGS_NOTIFY %}
 # If there are any errors from this point
 # send mail to {{ SCORM_S3_LOGS_NOTIFY_EMAIL }}
-{% if SCORM_S3_LOGS_NOTIFY %}
 onerror() {
   if [[ -z $noop ]]; then
     subj="Error syncing SCORM content to S3 bucket $bucket_name"


### PR DESCRIPTION
Break up SCORM-to-s3 syncs to go one directory at a time.  Syncing NYIF's was causing out of memory errors.  Also disable error notification emails by default, since they rely on mail software on the server.