### PR TITLE
Fix Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 # Travis CI configuration file for running tests
+---
 language: python
 python:
   - "2.7"
 
-branches:
-  only:
-  - master
-
 services:
   - docker
-  
+
 addons:
   apt:
     packages:
@@ -18,7 +15,7 @@ addons:
 
 before_install:
   - sudo apt-get -y update
-  - sudo apt-get -y install -o Dpkg::Options::="--force-confold" docker-engine
+  - sudo apt-get -y install -o Dpkg::Options::="--force-confold" docker-ce
 
 install:
   - "pip install --allow-all-external -r requirements.txt"


### PR DESCRIPTION
Update the Travis CI config so we can run it against all of our branches (most importantly, PRs), and a simple fix (docker package name changed).

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
