### PR TITLE
Fix supervisor tasks and improve tag usage

### DIFF
--- a/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
+++ b/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
@@ -1,18 +1,13 @@
 - hosts: "edxapp-server"
   become: true
+  vars_files:
+    - roles/common_vars/defaults/main.yml
+    - roles/supervisor/defaults/main.yml
+    - roles/edxapp/defaults/main.yml
 
   # Update extra requirements, private requirements, 
-  # collect static assets, and restart edx app and workers
-
+  # migrate (if indicated), collect static assets, and restart edx app and workers
   tasks:
-    - include_vars: roles/common_vars/defaults/main.yml
-      tags:
-        - migrate
-        - gather_static_assets
-    - include_vars: roles/edxapp/defaults/main.yml
-      tags:
-        - migrate
-        - gather_static_assets
 
     - name: install read-only ssh key
       copy: >
@@ -98,9 +93,8 @@
         supervisorctl_path={{ supervisor_ctl }}
         config={{ supervisor_cfg }}
         name="edxapp:{{ item }}"
-      when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
       sudo_user: "{{ supervisor_service_user }}"
-      with_items: service_variants_enabled
+      with_items: "{{ service_variants_enabled }}"
       tags:
         - migrate
         - gather_static_assets
@@ -111,8 +105,7 @@
         supervisorctl_path={{ supervisor_ctl }}
         config={{ supervisor_cfg }}
         state=restarted
-      when: edxapp_installed is defined and celery_worker is defined and not disable_edx_services
-      with_items: edxapp_workers
-      sudo_user: "{{ common_web_user }}"
+      with_items: "{{ edxapp_workers }}"
+      sudo_user: "{{ supervisor_service_user }}"
       tags:
         - migrate

--- a/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
+++ b/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
@@ -6,8 +6,13 @@
 
   tasks:
     - include_vars: roles/common_vars/defaults/main.yml
+      tags:
+        - migrate
+        - gather_static_assets
     - include_vars: roles/edxapp/defaults/main.yml
-
+      tags:
+        - migrate
+        - gather_static_assets
 
     - name: install read-only ssh key
       copy: >
@@ -33,9 +38,6 @@
       when:
         - EDXAPP_INSTALL_PRIVATE_REQUIREMENTS is defined and EDXAPP_INSTALL_PRIVATE_REQUIREMENTS
         - EDXAPP_PRIVATE_REQUIREMENTS is defined and EDXAPP_PRIVATE_REQUIREMENTS
-      tags:
-        - install
-        - install:app-requirements
 
     - name: install python private requirements
       shell: >
@@ -46,9 +48,6 @@
       environment:
         GIT_SSH: "{{ edxapp_git_ssh }}"
       when: "{{ EDXAPP_INSTALL_PRIVATE_REQUIREMENTS }}"
-      tags:
-        - install
-        - install:app-requirements     
 
     - name: install python extra requirements
       pip: >
@@ -85,7 +84,6 @@
       with_items: ['absent', 'directory']
       tags:
         - gather_static_assets
-        - assets
 
     - name: "gather {{ item }} static assets with paver"
       command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
@@ -103,6 +101,9 @@
       when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
       sudo_user: "{{ supervisor_service_user }}"
       with_items: service_variants_enabled
+      tags:
+        - migrate
+        - gather_static_assets
 
     - name: restart edxapp_workers
       supervisorctl: >
@@ -113,3 +114,5 @@
       when: edxapp_installed is defined and celery_worker is defined and not disable_edx_services
       with_items: edxapp_workers
       sudo_user: "{{ common_web_user }}"
+      tags:
+        - migrate

--- a/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
+++ b/playbooks/appsemblerPlaybooks/update_custom_requirements.yml
@@ -1,5 +1,7 @@
 - hosts: "edxapp-server"
   become: true
+  vars:
+    migrate_db: "yes"
   vars_files:
     - roles/common_vars/defaults/main.yml
     - roles/supervisor/defaults/main.yml


### PR DESCRIPTION
3 of the tasks were never running.  I fixed the conditionals for the migrate and restart `edxapp:` and `edxapp_workers:` tasks.  Tags are set up now with the idea that `migrate` can be run if desired (but will not run unless you have set `migrate_db: true` in your server-vars)  and `collect_static_assets` tag is there mostly to exclude that tag if desired (you know that no static assets are contained or changed in your change to the custom requirements).  The other tags were not really necessary as this is a standalone playbook.