### PR TITLE
add json formatted nginx logs

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -94,6 +94,7 @@ error_page {{ k }} {{ v }};
   server_name {{ CMS_HOSTNAME }};
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
+  access_log {{ nginx_log_dir }}/access_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -54,6 +54,7 @@ server {
   root {{ kibana_app_dir }}/htdocs;
 
   access_log {{ nginx_log_dir }}/kibana.access.log;
+  access_log {{ nginx_log_dir }}/kibana.access_json.log json_combined;
   error_log {{ nginx_log_dir }}/kibana.error.log error;
 
   # Access restriction

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
@@ -53,6 +53,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
+  access_log {{ nginx_log_dir }}/access_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -160,6 +160,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
+  access_log {{ nginx_log_dir }}/access_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -41,7 +41,20 @@ http {
                                 '"$request" $status $body_bytes_sent $request_time '
                                 '"$http_referer" "$http_user_agent"';
 
+        log_format json_combined '{"time_local": "$time_iso8601", '
+                             '"remote_addr": "$remote_addr", '
+                             '"remote_user": "$remote_user", '
+                             '"request": "$request", '
+                             '"request_method": "$request_method", '
+                             '"request_uri": "$request_uri", '
+                             '"status": "$status", '
+                             '"body_bytes_sent": "$body_bytes_sent", '
+                             '"request_time": "$request_time", '
+                             '"http_referrer": "$http_referer", '
+                             '"http_user_agent": "$http_user_agent"}';
+
         access_log {{ nginx_log_dir }}/access.log p_combined;
+        access_log {{ nginx_log_dir }}/access_json.log json_combined;
         error_log {{ nginx_log_dir }}/error.log;
 
         ##

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -129,7 +129,7 @@ if [[ "xenial" = "${SHORT_DIST}" ]]; then
     #apt-get install -y build-essential sudo git-core libmysqlclient-dev
 else
     #apt-get install -y python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 build-essential sudo git-core libmysqlclient-dev
-    pip install --upgrade pip=="${PIP_VERSION}"
+    pip install -i https://pypi.python.org/simple --upgrade pip=="${PIP_VERSION}"
 fi
 
 # pip moves to /usr/local/bin when upgraded

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -50,6 +50,7 @@ CONFIGURATION_DIR="/tmp/configuration"
 EDX_PPA="deb http://ppa.edx.org precise main"
 EDX_PPA_KEY_SERVER="keyserver.ubuntu.com"
 EDX_PPA_KEY_ID="B41E5E3969464050"
+PIP_INDEX_URL="https://pypi.python.org/simple/"
 
 cat << EOF
 ******************************************************************************


### PR DESCRIPTION
Add JSON formatted nginx logs. We have this on AMC, but it's time to get some performance metrics on the edX side as well.

Structured logs are much easier to ingest for monitoring and metrics. I also need the `request_time` field in the logs for monitoring performance. It's safer to just add it in a new log rather than change the format of the existing nginx logs (since any tools that are parsing them have probably hard-coded patterns).

Nginx 1.11.8 adds a `escape=json` directive that makes this safer, but we're not on that version yet. That means that currently, some particularly bad values of user agents or referers could make that line of the log invalid JSON. Generally, this hasn't been much of a problem, but any tool parsing these logs needs to keep that in mind and be ready to exclude a bad line here and there. (I've been parsing these on AMC for a few weeks now and it hasn't been an issue).

We're also effectively doubling our disk usage for logs. Again, on AMC, this has not been an issue. Logrotate is configured to compress and rotate any `*.log` files in the directory, so it picks these up as well and the overall effect seems minimal.