### PR TITLE
define shards for test.syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - "pip install --allow-all-external demjson"
 
 env:
-  - MAKE_TARGET=test.syntax
+  - MAKE_TARGET=test.syntax SHARD=0 SHARDS=1
   - MAKE_TARGET=test.edx_east_roles
   - MAKE_TARGET=docker.test.shard SHARD=0 SHARDS=3
   - MAKE_TARGET=docker.test.shard SHARD=1 SHARDS=3

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -28,3 +28,4 @@ weights:
   - docker-tools: 3
   - tools_jenkins: 8
   - ecomworker: 4
+  - course_discovery: 2


### PR DESCRIPTION
This target fails when travis runs it because it expects `SHARD` and `SHARDS` to be set to valid values.

```
$ travis_wait 50 make --keep-going $MAKE_TARGET SHARD=$SHARD SHARDS=$SHARDS
Still running (1 of 50): make --keep-going test.syntax SHARD= SHARDS=
The command make --keep-going test.syntax SHARD= SHARDS= exited with 2.
Log:
awk: cmd. line:1: NR%==
awk: cmd. line:1:     ^ syntax error
usage: balancecontainers.py [-h] num_shards
balancecontainers.py: error: too few arguments
awk: cmd. line:1: NR%==
awk: cmd. line:1:     ^ syntax error
usage: balancecontainers.py [-h] num_shards
balancecontainers.py: error: too few arguments
```

Arguably, `balancecontainers.py` and/or the `awk` command should be fixed to just work properly without those variables set, but this seems like a quicker fix before investigating whether there's a proper fix in ginkgo/hawthorne.
