### PR TITLE
Skip logstash and filebeat for Ginkgo by default

### DIFF
--- a/playbooks/appsemblerPlaybooks/monitoring.yml
+++ b/playbooks/appsemblerPlaybooks/monitoring.yml
@@ -10,11 +10,19 @@
   roles:
     - sysdig
     - oraclejdk
-    - "{{ appsembler_roles }}/filebeat"
-    - "{{ appsembler_roles }}/logstash"
+
+    - role: "{{ appsembler_roles }}/filebeat"
+      when: "LOGSTASH_ENABLED|default(False)"
+
+    - role: "{{ appsembler_roles }}/logstash"
+      when: "LOGSTASH_ENABLED|default(False)"
+
     - role: "{{ appsembler_roles }}/stackdriver"
       when: "cloud_provider == 'gcp'"
+
     - "{{ appsembler_roles }}/monit"
+
     - "{{ appsembler_roles }}/snort"
+
     - role: newrelic
       when: COMMON_ENABLE_NEWRELIC


### PR DESCRIPTION
Do we use Logstash? Time to disable it for Ginkgo.