### PR TITLE
Fixups to SCORM role and cache-control no-store option for SCORM media assets

### DIFF
--- a/playbooks/roles/scorm/tasks/main.yml
+++ b/playbooks/roles/scorm/tasks/main.yml
@@ -15,6 +15,9 @@
   set_fact: 
     scorm_config: "{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock|default('{}') }}"
 
+- include_vars: ../../edxapp/defaults/main.yml
+- include_vars: ../../nginx/defaults/main.yml    
+
 - include: scorm_base.yml
   when: EDXAPP_XBLOCK_SETTINGS.ScormXBlock is defined
 

--- a/playbooks/roles/scorm/tasks/scorm_base.yml
+++ b/playbooks/roles/scorm/tasks/scorm_base.yml
@@ -1,14 +1,4 @@
 
-# to make sure we have the edxapp user without
-# adding a dependency on rull edxapp role, for convenience
-- name: create edxapp application user
-  user: >
-    name="{{ edxapp_user }}" home="{{ edxapp_app_dir }}"
-    createhome=no shell=/bin/false
-  tags:
-    - install
-    - install:base
-
 - name: create all service directories
   file: >
     path="{{ item.value.path }}"

--- a/playbooks/roles/scorm/templates/nginx_extra_templates/scorm_extra_locations_lms.j2
+++ b/playbooks/roles/scorm/templates/nginx_extra_templates/scorm_extra_locations_lms.j2
@@ -1,9 +1,14 @@
-location ~ ^/{{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] }}/(?P<file>.*) {
+location ^~ /{{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] }}/ {
     add_header 'Access-Control-Allow-Origin' '*';
     add_header 'Access-Control-Allow-Credentials' 'true';
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-
-    root {{ edxapp_media_dir }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] }};
-    try_files /$file =404;
+    
+    {% if EDXAPP_XBLOCK_SETTINGS.ScormXBlock.get('SCORM_MEDIA_NO_CACHE', False) %}
+    add_header 'Cache-Control' 'no-store';
+    {% else %}
     expires 31536000s;
+    {% endif %}
+
+    root {{ edxapp_media_dir }}/;
+    try_files $uri =404;
 }

--- a/playbooks/roles/scorm/templates/nginx_extra_templates/scorm_extra_locations_lms.j2
+++ b/playbooks/roles/scorm/templates/nginx_extra_templates/scorm_extra_locations_lms.j2
@@ -1,4 +1,4 @@
-location ^~ /{{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] }}/ {
+location ^~ {{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] }}/ {
     add_header 'Access-Control-Allow-Origin' '*';
     add_header 'Access-Control-Allow-Credentials' 'true';
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
@@ -9,6 +9,6 @@ location ^~ /{{ EDXAPP_MEDIA_URL }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM
     expires 31536000s;
     {% endif %}
 
-    root {{ edxapp_media_dir }}/;
+    root {{ edxapp_data_dir }}/;
     try_files $uri =404;
 }


### PR DESCRIPTION
* small fixes so role can be run independently with run_role.yml again, found it was only working as part of a full deploy playbook.
* make sure /media/scorm location in Nginx LMS config takes precedence over plain /media/ location
* if ScormXBlock configured with SCORM_MEDIA_NO_CACHE set to true, set  `cache-control: no-store` : this is needed at least for now until the XBlock and integration support versioning.