### PR TITLE
split out cms+lms json logs

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -94,7 +94,7 @@ error_page {{ k }} {{ v }};
   server_name {{ CMS_HOSTNAME }};
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
-  access_log {{ nginx_log_dir }}/access_json.log json_combined;
+  access_log {{ nginx_log_dir }}/access_cms_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
@@ -53,7 +53,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
-  access_log {{ nginx_log_dir }}/access_json.log json_combined;
+  access_log {{ nginx_log_dir }}/access_lms_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -160,7 +160,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
-  access_log {{ nginx_log_dir }}/access_json.log json_combined;
+  access_log {{ nginx_log_dir }}/access_lms_json.log json_combined;
   error_log {{ nginx_log_dir }}/error.log error;
 
   # CS184 requires uploads of up to 4MB for submitting screenshots.


### PR DESCRIPTION
I've found it simpler to parse them separately.