### PR TITLE
update raven to 6.9.0

### DIFF
--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -35,7 +35,7 @@
   tags: ['backups']
 
 - name: Install raven package for Sentry alerts
-  pip: name=raven version="5.27.1"
+  pip: name=raven version="6.9.0"
   tags: ['backups']
 
 - name: Copy boto configuration

--- a/playbooks/roles/insights_tracking_logs_sync/tasks/main.yml
+++ b/playbooks/roles/insights_tracking_logs_sync/tasks/main.yml
@@ -22,7 +22,7 @@
   tags: ['insights_tracking_logs_sync']
 
 - name: Install raven package for Sentry alerts
-  pip: name=raven version="5.27.1"
+  pip: name=raven version="6.9.0"
   tags: ['insights_tracking_logs_sync']
 
 - name: Copy boto configuration

--- a/playbooks/roles/tracking_logs_sync/tasks/main.yml
+++ b/playbooks/roles/tracking_logs_sync/tasks/main.yml
@@ -22,7 +22,7 @@
   tags: ['tracking_logs_sync']
 
 - name: Install raven package for Sentry alerts
-  pip: name=raven version="5.27.1"
+  pip: name=raven version="6.9.0"
   tags: ['tracking_logs_sync']
 
 - name: Copy boto configuration


### PR DESCRIPTION
backups monitoring requires a newer version than 5.27.1

Going through the [Changelog](https://github.com/getsentry/raven-python/blob/master/CHANGELOG.md) between 5.27.1 and 6.9.0, I don't see any backwards-incompatible changes that should impact us.

I'm not really familiar with how it is used in the `*_tracking_logs_sync` roles though.

I feel like we also should be pulling this out into a single setting somewhere instead of hard-coding the version in multiple places.