### PR TITLE
appsembler_reporting role

### DIFF
--- a/playbooks/appsemblerPlaybooks/ficus_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_basic.yml
@@ -81,3 +81,9 @@
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
+    - role: appsembler_reporting
+      when: 
+        - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
+        - "COMMON_ENVIRONMENT == 'prod'"
+      tags: ['appsembler_reporting_role']
+

--- a/playbooks/appsemblerPlaybooks/ficus_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_basic.yml
@@ -83,7 +83,6 @@
       tags: ['ecommerce_theme_role']
     - role: appsembler_reporting
       when: 
-        - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
+        - "EDXAPP_APPSEMBLER_FEATURES.ENABLE_APPSEMBLER_REPORTING|default(false)"
         - "COMMON_ENVIRONMENT == 'prod'"
       tags: ['appsembler_reporting_role']
-

--- a/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
@@ -142,7 +142,9 @@
   hosts: "edxapp-server-1"
   sudo: True
   gather_facts: True
-  when: 
-    - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
-    - "COMMON_ENVIRONMENT == 'prod'"
-  tags: ['appsembler_reporting_role']
+  roles: 
+    - role: appsembler_reporting
+      when: 
+        - "EDXAPP_APPSEMBLER_FEATURES.ENABLE_APPSEMBLER_REPORTING|default(false)"
+        - "COMMON_ENVIRONMENT == 'prod'"
+      tags: ['appsembler_reporting_role']

--- a/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_enterprise.yml
@@ -137,3 +137,12 @@
     - role: postgresql_aggregation
       when: COMMON_ENVIRONMENT == "prod"
       tags: ['postgresql_aggregation_role']
+
+- name: Install Appsembler Reporting
+  hosts: "edxapp-server-1"
+  sudo: True
+  gather_facts: True
+  when: 
+    - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
+    - "COMMON_ENVIRONMENT == 'prod'"
+  tags: ['appsembler_reporting_role']

--- a/playbooks/appsemblerPlaybooks/ficus_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_pro.yml
@@ -86,8 +86,8 @@
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
     - role: appsembler_reporting
-      when: 
-        - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
+      when:
+        - "EDXAPP_APPSEMBLER_FEATURES.ENABLE_APPSEMBLER_REPORTING|default(false)"
         - "COMMON_ENVIRONMENT == 'prod'"
       tags: ['appsembler_reporting_role']
 

--- a/playbooks/appsemblerPlaybooks/ficus_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ficus_pro.yml
@@ -85,6 +85,11 @@
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
+    - role: appsembler_reporting
+      when: 
+        - "EDXAPP_APPSEMBLER_FEATURES is defined and EDXAPP_APPSEMBLER_FEATURES.get('ENABLE_APPSEMBLER_REPORTING', False)"
+        - "COMMON_ENVIRONMENT == 'prod'"
+      tags: ['appsembler_reporting_role']
 
 - name: Install xqueue, notifier and rabbitmq
   hosts: mongo-server

--- a/playbooks/roles/appsembler_reporting/defaults/main.yml
+++ b/playbooks/roles/appsembler_reporting/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
 
+appsembler_reporting_log_dir: /edx/var/log/appsembler_reporting
+appsembler_reporting_scripts_dir: "{{ edxapp_app_dir }}/appsembler_reporting"
 appsembler_reporting_jobs:
   grades:
     cron_h: 0
     cron_m: 0
-  course_metrics:
+  courses:
     cron_h: 1
     cron_m: 0
   learners:

--- a/playbooks/roles/appsembler_reporting/defaults/main.yml
+++ b/playbooks/roles/appsembler_reporting/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+
+appsembler_reporting_jobs:
+  grades:
+    cron_h: 0
+    cron_m: 0
+  course_metrics:
+    cron_h: 1
+    cron_m: 0
+  learners:
+    cron_h: 2
+    cron_m: 0

--- a/playbooks/roles/appsembler_reporting/defaults/main.yml
+++ b/playbooks/roles/appsembler_reporting/defaults/main.yml
@@ -3,12 +3,12 @@
 appsembler_reporting_log_dir: /edx/var/log/appsembler_reporting
 appsembler_reporting_scripts_dir: "{{ edxapp_app_dir }}/appsembler_reporting"
 appsembler_reporting_jobs:
-  grades:
+  - name: grades
     cron_h: 0
     cron_m: 0
-  courses:
+  - name: courses
     cron_h: 1
     cron_m: 0
-  learners:
+  - name: learners
     cron_h: 2
     cron_m: 0

--- a/playbooks/roles/appsembler_reporting/tasks/main.yml
+++ b/playbooks/roles/appsembler_reporting/tasks/main.yml
@@ -13,27 +13,28 @@
     path: "{{ appsembler_reporting_scripts_dir }}"
     state: directory
     owner: edxapp
-    group: edxapp    
+    group: edxapp
+    mode: 0755
 
 - name: Create the reporting scripts
   copy:
     content: >
       source {{ edxapp_app_dir}}/edxapp_env;
       /edx/bin/python.edxapp /edx/bin/manage.edxapp lms --settings=aws_appsembler  \
-        generate_appsembler_report {{ item.key }} --no-delay  \
-        2>&1 | tee -a {{ appsembler_reporting_log_dir }}/{{ item.key }}_report.log
-    dest: "{{ appsembler_reporting_scripts_dir }}/{{ item.key }}_report.sh"
+        generate_appsembler_report {{ item.name }} --no-delay  \
+        2>&1 | tee -a {{ appsembler_reporting_log_dir }}/{{ item.name }}_report.log
+    dest: "{{ appsembler_reporting_scripts_dir }}/{{ item.name }}_report.sh"
     owner: edxapp
     group: edxapp
-    mode: 774
-  with_dict: "{{ appsembler_reporting_jobs }}"  
+    mode: 770
+  with_items: "{{ appsembler_reporting_jobs }}"  
 
 - name: cron jobs for appsembler_reporting tasks
   cron:
-    name: "run appsembler_reporting {{ item.key }} job"
+    name: "run appsembler_reporting {{ item.name }} job"
     user: "{{ edxapp_user }}"
     # Set to "minute hour * * *" for example "0 2 * * *"
-    hour: "{{ item.value.cron_h }}" # Hour of the day
-    minute: "{{ item.value.cron_m }}" # Minute of the hour
-    job: "bash -e {{ appsembler_reporting_scripts_dir }}/{{ item.key }}_report.sh"
+    hour: "{{ item.cron_h }}" # Hour of the day
+    minute: "{{ item.cron_m }}" # Minute of the hour
+    job: "bash -e {{ appsembler_reporting_scripts_dir }}/{{ item.name }}_report.sh"
   with_dict: "{{ appsembler_reporting_jobs }}"

--- a/playbooks/roles/appsembler_reporting/tasks/main.yml
+++ b/playbooks/roles/appsembler_reporting/tasks/main.yml
@@ -2,26 +2,38 @@
 
 - name: make logs directory for appsembler_reporting
   file:
-    path: "/edx/var/log/appsembler_reporting"
+    path: "{{ appsembler_reporting_log_dir }}"
     state: "directory"
     owner: "{{ edxapp_user }}"
-    group: "{{ edxapp_user }}"
+    group: syslog
     mode: 0755
 
-- name: make appsembler_reporting shell scripts
-  template:
-    src: "appsembler_reporting_job.sh.j2"
-    dest: "{{ edxapp_app_dir }}/appsembler_reporting_{{ item.key }}.sh"
-    owner: "{{ edxapp_user }}"
-    group: "{{ edxapp_user }}"
-    mode: 0740
-  with_dict: "{{ appsembler_reporting_jobs }}"
+- name: Create the reporting scripts directory
+  file:
+    path: "{{ appsembler_reporting_scripts_dir }}"
+    state: directory
+    owner: edxapp
+    group: edxapp    
+
+- name: Create the reporting scripts
+  copy:
+    content: >
+      source {{ edxapp_app_dir}}/edxapp_env;
+      /edx/bin/python.edxapp /edx/bin/manage.edxapp lms --settings=aws_appsembler  \
+        generate_appsembler_report {{ item.key }} --no-delay  \
+        2>&1 | tee -a {{ appsembler_reporting_log_dir }}/{{ item.key }}_report.log
+    dest: "{{ appsembler_reporting_scripts_dir }}/{{ item.key }}_report.sh"
+    owner: edxapp
+    group: edxapp
+    mode: 774
+  with_dict: "{{ appsembler_reporting_jobs }}"  
 
 - name: cron jobs for appsembler_reporting tasks
   cron:
     name: "run appsembler_reporting {{ item.key }} job"
     user: "{{ edxapp_user }}"
-    hour: "{{ item.value.cron_h }}"
-    minute: "{{ item.value.cron_m }}"
-    job: "{{ edxapp_app_dir }}/appsembler_reporting_{{ item.key }}.sh >> /edx/var/log/appsembler_reporting/{{ item.key }}_report.log 2>&1"
+    # Set to "minute hour * * *" for example "0 2 * * *"
+    hour: "{{ item.value.cron_h }}" # Hour of the day
+    minute: "{{ item.value.cron_m }}" # Minute of the hour
+    job: "bash -e {{ appsembler_reporting_scripts_dir }}/{{ item.key }}_report.sh"
   with_dict: "{{ appsembler_reporting_jobs }}"

--- a/playbooks/roles/appsembler_reporting/tasks/main.yml
+++ b/playbooks/roles/appsembler_reporting/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: make logs directory for appsembler_reporting
+  file:
+    path: "/edx/var/log/appsembler_reporting"
+    state: "directory"
+    owner: "{{ edxapp_user }}"
+    group: "{{ edxapp_user }}"
+    mode: 0755
+
+- name: make appsembler_reporting shell scripts
+  template:
+    src: "appsembler_reporting_job.sh.j2"
+    dest: "{{ edxapp_app_dir }}/appsembler_reporting_{{ item.key }}.sh"
+    owner: "{{ edxapp_user }}"
+    group: "{{ edxapp_user }}"
+    mode: 0740
+  with_dict: "{{ appsembler_reporting_jobs }}"
+
+- name: cron jobs for appsembler_reporting tasks
+  cron:
+    name: "run appsembler_reporting {{ item.key }} job"
+    user: "{{ edxapp_user }}"
+    hour: "{{ item.value.cron_h }}"
+    minute: "{{ item.value.cron_m }}"
+    job: "{{ edxapp_app_dir }}/appsembler_reporting_{{ item.key }}.sh >> /edx/var/log/appsembler_reporting/{{ item.key }}_report.log 2>&1"
+  with_dict: "{{ appsembler_reporting_jobs }}"

--- a/playbooks/roles/appsembler_reporting/templates/appsembler_reporting_job.sh.j2
+++ b/playbooks/roles/appsembler_reporting/templates/appsembler_reporting_job.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+source {{ edxapp_app_dir }}/edxapp_env
+python {{ edxapp_app_dir}}/edx-platform/manage.py lms --settings=aws_appsembler generate_appsembler_report {{ item.key }} --no-delay

--- a/playbooks/roles/appsembler_reporting/templates/appsembler_reporting_job.sh.j2
+++ b/playbooks/roles/appsembler_reporting/templates/appsembler_reporting_job.sh.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-source {{ edxapp_app_dir }}/edxapp_env
-python {{ edxapp_app_dir}}/edx-platform/manage.py lms --settings=aws_appsembler generate_appsembler_report {{ item.key }} --no-delay


### PR DESCRIPTION
This adds an appsembler_reporting role to create the shell scripts, cron jobs, and log dirs to run and log the reports.

Installs the edxapp server; or, in the case of enterprise customers, to edxapp server 1.