### PR TITLE
include nginx json log files in logrotate conf

### DIFF
--- a/playbooks/roles/nginx/templates/etc/logrotate.d/edx_logrotate_nginx_access.j2
+++ b/playbooks/roles/nginx/templates/etc/logrotate.d/edx_logrotate_nginx_access.j2
@@ -1,6 +1,6 @@
 # Put in place by ansible
 
-{{ nginx_log_dir }}/*access.log {
+{{ nginx_log_dir }}/*access*.log {
   create 0640 www-data adm
   compress
   delaycompress


### PR DESCRIPTION
The more detailed json log files have filenames like `access_lms_json.log` or `access_cms_json.log`. The logrotate config was missing them so they've just been growing for the last month or two on Tahoe. This should make sure they get rotated as well and don't just fill up the disk endlessly.
