### PR TITLE
make nginx server_names_hash_bucket_size configurable

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -7,6 +7,8 @@ nginx_redirects: {}
 nginx_extra_sites: []
 nginx_extra_configs: []
 
+nginx_server_names_hash_bucket_size: 64
+
 # Appsembler custom
 ALLOW_BASIC_AUTH: false
 nginx_cms_client_max_body_size: 100M

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -23,7 +23,7 @@ http {
         large_client_header_buffers 4 16k;
         # server_tokens off;
 
-        # server_names_hash_bucket_size 64;
+        server_names_hash_bucket_size {{ nginx_server_names_hash_bucket_size }};
         # server_name_in_redirect off;
 
         include /etc/nginx/mime.types;


### PR DESCRIPTION
With more than a couple additional domains all listening on the same interface, nginx refuses to start:

```
# nginx -t
nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
nginx: configuration file /etc/nginx/nginx.conf test failed
```

We are running into this on Tahoe staging.

This PR simply makes it a variable that we can configure (but keeps it at the default 64, so any existing deploys will be unaffected).