### PR TITLE
Maintenance mode for Ginkgo

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -110,6 +110,7 @@ nginx_debian_pkgs:
   - python-passlib
 
 NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False
+NGINX_EDXAPP_ENABLE_LOCAL_MAINTENANCE: False
 nginx_default_error_page: "/server/server-error.html"
 nginx_maintenance_page: "/server/server-maintenance.html"
 NGINX_EDXAPP_ERROR_PAGES:

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -87,6 +87,11 @@ NGINX_SERVER_HTML_FILES:
     msg: 'We have been notified of the error, if it persists please let us know at <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     heading: 'Uh oh, we are having some server issues..'
+  - file: server-maintenance.html
+    title: '{{ EDXAPP_PLATFORM_NAME }} temporarily unavailable'
+    msg: 'A maintenance operation is currently in progress on our system that will affect your access to our online courses.<br/><br/>If you have any questions or concerns, please contact <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
+    img: "{{ NGINX_SERVER_ERROR_IMG }}"
+    heading: 'Maintenance in Progress'
 
 NGINX_APT_REPO: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 
@@ -106,10 +111,12 @@ nginx_debian_pkgs:
 
 NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False
 nginx_default_error_page: "/server/server-error.html"
+nginx_maintenance_page: "/server/server-maintenance.html"
 NGINX_EDXAPP_ERROR_PAGES:
   "500": "{{ nginx_default_error_page }}"
   "502": "{{ nginx_default_error_page }}"
   "504": "{{ nginx_default_error_page }}"
+  "503": "{{ nginx_maintenance_page }}"
 
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 ECOMMERCE_HOSTNAME: '~^((stage|prod)-)?ecommerce.*'

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -158,6 +158,7 @@
   tags:
     - install
     - install:configuration
+    - nginx:maintenance
 
 - name: Creating nginx config links for {{ nginx_sites }}
   file:
@@ -311,6 +312,7 @@
   tags:
     - install
     - install:configuration
+    - nginx:maintenance
 
 # appsembler mod ..when ALLOW_BASIC_AUTH
 - name: Write out htpasswd file

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -108,6 +108,11 @@ error_page {{ k }} {{ v }};
   {% include "common-settings.j2" %}
 
   location @proxy_to_cms_app {
+    {% if NGINX_EDXAPP_ENABLE_LOCAL_MAINTENANCE %}
+    return 503;
+    {% endif %}
+
+
     {% if NGINX_SET_X_FORWARDED_HEADERS %}
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
@@ -131,6 +136,7 @@ error_page {{ k }} {{ v }};
     {% if EDXAPP_CMS_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}
     {% endif %}
+
     try_files $uri @proxy_to_cms_app;
   }
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -189,6 +189,11 @@ error_page {{ k }} {{ v }};
   {% endif -%}
 
   location @proxy_to_lms_app {
+
+    {% if NGINX_EDXAPP_ENABLE_LOCAL_MAINTENANCE %}
+    return 503;
+    {% endif %}
+
     {% if NGINX_SET_X_FORWARDED_HEADERS %}
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;


### PR DESCRIPTION
Creates a `server-maintenance.html` page by templates, sets it for use on 503 errors.
Allows enabling (default False of course) of a local maintenance mode (edX uses an S3 setup which is cumbersome across many deploys). When activated (run Ansible `nginx:maintenance` tag with `NGINX_EDXAPP_ENABLE_LOCAL_MAINTENANCE` set to true), all requests proxied to LMS and CMS will return a 503 and show the maintenance page.

This incorporates and builds on the Ficus maintenance-mode feature.  Next PR is to extend for Ficus (for Ficus -> later upgrades).