### PR TITLE
Always rebuild forum indexes during migration

### DIFF
--- a/playbooks/appsemblerPlaybooks/ginkgo_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_basic.yml
@@ -12,6 +12,7 @@
   vars:
     appsembler_roles: "../../../appsembler-roles"
     migrate_db: "yes"
+    FORUM_REBUILD_INDEX: true
     SANDBOX_ENABLE_ECOMMERCE: False
     COMMON_ENABLE_INSIGHTS: False
     COMMON_ENABLE_OAUTH_CLIENT: False

--- a/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
@@ -40,6 +40,7 @@
   vars:
     appsembler_roles: "../../../appsembler-roles"
     migrate_db: "yes"
+    FORUM_REBUILD_INDEX: true
     openid_workaround: True
     SANDBOX_ENABLE_ECOMMERCE: False
     COMMON_ENABLE_INSIGHTS: False

--- a/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
@@ -31,6 +31,7 @@
   vars:
     appsembler_roles: "../../../appsembler-roles"
     migrate_db: "yes"
+    FORUM_REBUILD_INDEX: true
     openid_workaround: True
     POSTGRESQL_AGGREGATION_INSTALL_CRON: true
     ENABLE_ECOMMERCE: false


### PR DESCRIPTION
We've been bitten a couple times during upgrades because this variable defaults to False, and the elasticsearch indexes of the comments service don't get rebuilt.  Maybe we should just default it to True.