### PR TITLE
Collectstatic in temp

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -192,29 +192,69 @@
   tags:
     - migrate
 
-# There are problems with django collectstatic copying files.  It doesn't retain
-# last modified timestamps, but relies on those same timestamps to know if a new file
-# should be recopied.  While collectstatic --clear exists, it only clears some of the
-# files in edxapp_staticfile_dir, it leaves postprocessed or otherwise hashed files.
-# This ensures we have a totally clean directory.
-- name: Remove and recreate the staticfiles directory so nothing stale can exist
-  file:
-      path: "{{ edxapp_staticfile_dir }}"
-      state: "{{ item }}"
-      owner: "{{ edxapp_user }}"
-      group: "{{ common_web_group }}"
-      mode:  "0755"
-  when: celery_worker is not defined and not devstack
-  with_items: ['absent', 'directory']
+# to avoid the running site breaking while collectstatic runs, we
+# generate a temp dir, make a new temporary configuration that points
+# STATIC_ROOT at that temp dir, runs the collectstatic to populate it,
+# then swaps in that temp dir in place of the actual staticfiles
+# directory in one quick step
+
+- name: Create temporary staticfiles directory
+  tempfile:
+    state: directory
+    suffix: staticfiles
+    owner: "{{ edxapp_user }}"
+    group: "{{ common_web_group }}"
+  register: staticfiles_tmpdir
+  when: celery_worker is not defined and not devstack and item != "lms-preview"
   tags:
     - gather_static_assets
     - assets
 
-# Gather assets using paver if possible
+- name: "generate new {{ item }} override config"
+  template:
+    src: staticfiles_override.py.j2
+    dest: "{{ edxapp_code_dir }}/{{ item }}/envs/staticfiles_override.py"
+    owner: "{{ edxapp_user }}"
+    group: "{{ common_web_group }}"
+    mode: 0640
+  with_items: "{{ service_variants_enabled }}"
+  when: celery_worker is not defined and not devstack and item != "lms-preview"
+  tags:
+    - gather_static_assets
+    - assets
+
+# Gather assets using paver
 - name: "gather {{ item }} static assets with paver"
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
+  environment:
+    EDX_PLATFORM_SETTINGS_OVERRIDE: "staticfiles_override"
   when: celery_worker is not defined and not devstack and item != "lms-preview"
   with_items: "{{ service_variants_enabled }}"
+  tags:
+    - gather_static_assets
+    - assets
+
+# Replace staticfiles dirs
+- name: Move staticfiles out of the way
+  command: "mv {{ edxapp_staticfile_dir }} /tmp/old_staticfiles_dir"
+  when: celery_worker is not defined and not devstack and item != "lms-preview"
+  tags:
+    - gather_static_assets
+    - assets
+
+- name: Replace with new version of staticfiles
+  command: "mv {{ staticfiles_tmpdir.path }} {{ edxapp_staticfile_dir}}"
+  when: celery_worker is not defined and not devstack and item != "lms-preview"
+  tags:
+    - gather_static_assets
+    - assets
+
+- name: "Remove {{ item }} temporary staticfiles config"
+  file:
+    path: "{{ edxapp_code_dir }}/{{ item }}/envs/staticfiles_override.py"
+    state: absent
+  with_items: "{{ service_variants_enabled }}"
+  when: celery_worker is not defined and not devstack and item != "lms-preview"
   tags:
     - gather_static_assets
     - assets

--- a/playbooks/roles/edxapp/templates/staticfiles_override.py
+++ b/playbooks/roles/edxapp/templates/staticfiles_override.py
@@ -1,0 +1,3 @@
+from .{{ edxapp_settings }} import *
+
+STATIC_ROOT = "{{ staticfiles_tmpdir.path }}"


### PR DESCRIPTION
The current deploy process deletes the contents of the staticfiles directory to prevent stale files from ending up there. Then it runs the (paver equivalent) collectstatic command to generate them fresh. Unfortunately, when this runs on a live site, the whole site is broken for the period after the old ones are deleted until the new ones are created. On Tahoe, this is a good 10-15 minutes and represents the largest chunk of downtime that we have to schedule for doing maintenance.

This approach instead runs the collectstatic against a temp directory and swaps that out for the real staticfiles dir only after it has completed. This has a couple advantages:

1. while it is running, the live site is unaffected. Users won't have broken CSS/JS
2. If the collectstatic step fails or the connection is interrupted during that step of the deploy, the site will again be unaffected. With the current approach, a failure here leaves the site broken until someone can fix it.

What I have right now is roughly equivalent to running some commands on the server like:

* `mkdir /tmp/staticfiles_asdf` (it gets a random directory to avoid conflicts)
* `echo "from .amc import *\n\nSTATIC_ROOT = '/tmp/staticfiles_asdf` > /edx/app/edxapp/edx-platform/lms/envs/staticfiles_override.py`
* `echo "from .amc import *\n\nSTATIC_ROOT = '/tmp/staticfiles_asdf` > /edx/app/edxapp/edx-platform/cms/envs/staticfiles_override.py`
* `EDX_PLATFORM_SETTINGS_OVERRIDE=staticfiles_override /edx/bin/edxapp-update-assets-cms`
* `EDX_PLATFORM_SETTINGS_OVERRIDE=staticfiles_override /edx/bin/edxapp-update-assets-lms`
* `mv /edx/var/edxapp/staticfiles /tmp/old_staticfiles`
* `mv /tmp/staticfiles_asdf /edx/var/edxapp/staticfiles`
* `rm edx/app/edxapp/edx-platform/{cms,lms}/envs/staticfiles_override.py`

An improvement over this, to make the swap truly atomic would be for the staticfiles dir to be a symlink to another directory. With the above approach, an interruption in between those two `mv` commands at the end can leave things in a broken state (it's just a much smaller window than the current version). If we instead swapped a symlink around, the Linux kernel actually does that as a guaranteed atomic operation. But that would take some additional conversion work to change the existing directory layout first. I see this PR as a temporary measure to improve things until we can get a better docker deploy setup going, so it's probably not worth the effort to do the symlink approach.

We probably don't need to keep the old static files around (in `/tmp/old_staticfiles`) and we could just delete the directory instead. Long term that's cleaner. But for now I think it's worth holding on to it in case someone needs to do a manual roll back or if we are trying to debug something in the static file generation and want to do a diff.