### PR TITLE
Fix Mongo backups and add nginx edx_notes_api

### DIFF
--- a/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
@@ -73,6 +73,7 @@
       - cms
       - lms
       - forum
+      - edx_notes_api
       nginx_default_sites:
       - lms
       tags: ['nginx_role']

--- a/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
@@ -61,6 +61,7 @@
       - cms
       - lms
       - forum
+      - edx_notes_api
       nginx_default_sites:
       - lms
       tags: ['nginx_role']

--- a/playbooks/roles/backups/files/backup.py
+++ b/playbooks/roles/backups/files/backup.py
@@ -74,7 +74,8 @@ def upload_to_gcloud_storage(file_path, bucket):
     """
 
     import boto
-
+    import gcs_oauth2_boto_plugin
+    
     logging.info('Uploading backup at "{}" to Google Cloud Storage bucket '
                  '"{}"'.format(file_path, bucket))
 

--- a/playbooks/roles/backups/files/backup.py
+++ b/playbooks/roles/backups/files/backup.py
@@ -74,8 +74,8 @@ def upload_to_gcloud_storage(file_path, bucket):
     """
 
     import boto
-    import gcs_oauth2_boto_plugin
-    
+    import gcs_oauth2_boto_plugin #is needed to authenticate/upload backups to gc storage
+
     logging.info('Uploading backup at "{}" to Google Cloud Storage bucket '
                  '"{}"'.format(file_path, bucket))
 


### PR DESCRIPTION
Description

- After upgrading OU to Ginkgo Mongo update was failing with `NoAuthHandlerFound` error [https://sentry.io/appsembler/ou-ginkgo/issues/686363523/?query=is:unresolved](url) we need to add `gcs_oauth2_boto_plugin ` to be able to authenticate in gcp and be able to upload files to right storage

- OU is pro customer and using `edx_notes_api` but our current playbook for `ginkgo_pro` is not creating any nginx directory under site-available for edx-notes and the problem is we are missing `edx_notes_api` under nginx sites for nginx role

---
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
