### PR TITLE
include more tasks in `update_lms_theme`

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -38,6 +38,7 @@
     - install:base
     - deploy:platform
     - install:app-requirements
+    - update_lms_theme
 
 - name: set git fetch.prune to ignore deleted remote refs
   shell: git config --global fetch.prune true
@@ -45,6 +46,7 @@
   tags:
     - install
     - install:base
+    - update_lms_theme
 
 # Do A Checkout
 - name: checkout edx-platform repo into {{ edxapp_code_dir }}
@@ -417,6 +419,7 @@
     - install:code
     - deploy:platform
     - install:app-requirements
+    - update_lms_theme
 
 - include: tag_ec2.yml tags=deploy
   when: COMMON_TAG_EC2_INSTANCE

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -209,6 +209,7 @@
   tags:
     - gather_static_assets
     - assets
+    - update_lms_theme
 
 # Gather assets using paver if possible
 - name: "gather {{ item }} static assets with paver"
@@ -218,3 +219,4 @@
   tags:
     - gather_static_assets
     - assets
+    - update_lms_theme


### PR DESCRIPTION
Need to make sure the git ssh key is there first and need to run collectstatic tasks after updating.

Running the ansible playbook with the `update_lms_theme` tag currently fails with:

```
TASK [edxapp : checkout comprehensive themes] **********************************
failed: [104.196.20.208] (item={'key': u'staging-tahoe.appsembler.com', 'value': {'theme_source_repo': u'git@github.com:appsembler/edx-theme-codebase.git', 'theme_version': 
u'ficus/master', 'theme_name': u'edx-theme-codebase', 'customer_theme_version': u'ficus/amc', 'customer_theme_source_repo': u'https://github.com/appsembler/edx-theme-custome
rs.git'}}) => {"cmd": ["/usr/bin/git", "fetch", "--tags", "origin"], "failed": true, "item": {"key": "staging-tahoe.appsembler.com", "value": {"customer_theme_source_repo": 
"https://github.com/appsembler/edx-theme-customers.git", "customer_theme_version": "ficus/amc", "theme_name": "edx-theme-codebase", "theme_source_repo": "git@github.com:apps
embler/edx-theme-codebase.git", "theme_version": "ficus/master"}}, "msg": "Failed to download remote objects and refs:  Warning: Identity file /edx/app/edxapp/edxapp-git-ide
ntity not accessible: No such file or directory.\nPermission denied (publickey).\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct ac
cess rights\nand the repository exists.\n"}
failed: [104.196.198.232] (item={'key': u'staging-tahoe.appsembler.com', 'value': {'theme_source_repo': u'git@github.com:appsembler/edx-theme-codebase.git', 'theme_version':
 u'ficus/master', 'theme_name': u'edx-theme-codebase', 'customer_theme_version': u'ficus/amc', 'customer_theme_source_repo': u'https://github.com/appsembler/edx-theme-custom
ers.git'}}) => {"cmd": ["/usr/bin/git", "fetch", "--tags", "origin"], "failed": true, "item": {"key": "staging-tahoe.appsembler.com", "value": {"customer_theme_source_repo":
 "https://github.com/appsembler/edx-theme-customers.git", "customer_theme_version": "ficus/amc", "theme_name": "edx-theme-codebase", "theme_source_repo": "git@github.com:app
sembler/edx-theme-codebase.git", "theme_version": "ficus/master"}}, "msg": "Failed to download remote objects and refs:  Warning: Identity file /edx/app/edxapp/edxapp-git-id
entity not accessible: No such file or directory.\nPermission denied (publickey).\r\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct a
ccess rights\nand the repository exists.\n"}
        to retry, use: --limit @/tmp/tahoe-deploy/2018-09-19-14:21:33/configuration/playbooks/amc.retry
```

I think this is clearly because the tasks for placing our temporary read-only github ssh key on the server is not included in this tag.

I'm also pretty sure that to reliably update the themes, we also need to run the `collectstatic` task afterward (correct me if I'm wrong).

Context: On AMC at least, we do theme changes pretty often and it would be good to be able to deploy those quickly without incurring all the unrelated parts of a regular deploy (no need to update mongodb configs, pip install the entire world, restart services, etc). It appears that the `update_lms_theme` tag was already there for this purpose. But it clearly doesn't include everything that it needs. 

One other thing that is not included in the `update_lms_theme` is nodejs/npm related stuff. Specifically, this task: https://github.com/appsembler/configuration/blob/9fed585debdd89f6803d12eff05bfa703ecee739/playbooks/roles/edxapp/tasks/deploy.yml#L271 that runs `npm` in the edxapp directory. I'm not sure if that is needed on a theme change or not (it doesn't look like we change anything in `package.json` from `edx-theme-customers` or `edx-theme-codebase`). But maybe @grozdanowski can comment on that.

Also note that the `update_lms_theme` tag is a bit misleading as (afaict), it also updates the cms theme. We can rename that tag later though.