### PR TITLE
Necessary configs for using discovery and jenkins repo change

### DIFF
--- a/playbooks/appsemblerPlaybooks/ginkgo_basic.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_basic.yml
@@ -85,3 +85,5 @@
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
+    - role: discovery
+      when: SANDBOX_ENABLE_DISCOVERY

--- a/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
@@ -99,6 +99,8 @@
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
+    - role: discovery
+      when: SANDBOX_ENABLE_DISCOVERY
 
 - name: Install xqueue, notifier and rabbitmq on services instance
   hosts: services-server

--- a/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_pro.yml
@@ -90,6 +90,8 @@
     - role: ecommerce_theme
       when: ENABLE_ECOMMERCE
       tags: ['ecommerce_theme_role']
+    - role: discovery
+      when: SANDBOX_ENABLE_DISCOVERY
 
 - name: Install xqueue, notifier and rabbitmq
   hosts: mongo-server

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -227,12 +227,25 @@
 
 - name: Copying nginx configs for the service
   template:
+    src: "edx/app/nginx/sites-available/discovery.j2"
+    dest: "{{ nginx_sites_available_dir }}/{{ edx_django_service_name }}"
+    owner: root
+    group: "{{ common_web_user }}"
+    mode: 0640
+  when: nginx_app_dir is defined and SANDBOX_ENABLE_DISCOVERY == True
+  notify: reload nginx
+  tags:
+    - install
+    - install:vhosts
+
+- name: Copying nginx configs for the service
+  template:
     src: "edx/app/nginx/sites-available/app.j2"
     dest: "{{ nginx_sites_available_dir }}/{{ edx_django_service_name }}"
     owner: root
     group: "{{ common_web_user }}"
     mode: 0640
-  when: nginx_app_dir is defined
+  when: nginx_app_dir is defined and SANDBOX_ENABLE_DISCOVERY == False
   notify: reload nginx
   tags:
     - install

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/discovery.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/discovery.j2
@@ -1,0 +1,104 @@
+#
+# {{ ansible_managed }}
+#
+
+{% if nginx_default_sites is defined and edx_django_service_name in nginx_default_sites %}
+  {% set default_site = "default_server" %}
+{% else %}
+  {% set default_site = "" %}
+{% endif %}
+
+upstream {{ edx_django_service_name }}_app_server {
+{% for host in nginx_edx_django_service_gunicorn_hosts %}
+    server {{ host }}:{{ edx_django_service_gunicorn_port }} fail_timeout=0;
+{% endfor %}
+}
+
+# The Origin request header indicates where a fetch originates from. It doesn't include any path information,
+# but only the server name (e.g. https://www.example.com).
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin for details.
+#
+# Here we set the value that is included in the Access-Control-Allow-Origin response header. If the origin is one
+# of our known hosts--served via HTTP or HTTPS--we allow for CORS. Otherwise, we set the "null" value, disallowing CORS.
+map $http_origin $cors_origin {
+default "null";
+{% for host in edx_django_service_cors_whitelist %}
+  "~*^https?:\/\/{{ host|replace('.', '\.') }}$" $http_origin;
+{% endfor %}
+}
+
+server {
+  server_name {{ DISCOVERY_HOSTNAME }};
+
+  {% if NGINX_ENABLE_SSL %}
+
+  listen {{ edx_django_service_nginx_port }} {{ default_site }};
+  listen {{ edx_django_service_ssl_nginx_port }} ssl;
+
+  ssl_certificate {{ NGINX_SSL_CERTIFICATE_PATH }};
+  ssl_certificate_key {{ NGINX_SSL_KEY_PATH }};
+
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+  {% else %}
+  listen {{ edx_django_service_nginx_port }} {{ default_site }};
+  {% endif %}
+
+  location ~ ^/static/(?P<file>.*) {
+    root {{ COMMON_DATA_DIR }}/{{ edx_django_service_name }};
+    add_header 'Access-Control-Allow-Origin' $cors_origin;
+
+    # Inform downstream caches to take certain headers into account when reading/writing to cache.
+    add_header 'Vary' 'Accept-Encoding,Origin';
+
+    try_files /staticfiles/$file =404;
+  }
+
+  location ~ ^/media/(?P<file>.*) {
+    root {{ COMMON_DATA_DIR }}/{{ edx_django_service_name }};
+    try_files /media/$file =404;
+  }
+
+  location / {
+    {% if edx_django_service_enable_basic_auth|bool %}
+      {% include 'basic-auth.j2' %}
+    {% endif %}
+
+    try_files $uri @proxy_to_app;
+  }
+
+  # API endpoints have their own authentication and authorization
+  # schemes, so we bypass basic auth.
+  location ~ ^/({{ edx_django_service_basic_auth_exempted_paths | join('|') }})/ {
+    try_files $uri @proxy_to_app;
+  }
+
+  {% include 'robots.j2' %}
+
+  location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://{{ edx_django_service_name }}_app_server;
+  }
+
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
+  }
+
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+}

--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -92,7 +92,7 @@ jenkins_bundled_plugins:
 
 jenkins_custom_plugins:
     - { repo_name: "github-sqs-plugin",
-        repo_url: "https://github.com/jzoldak/github-sqs-plugin.git",
+        repo_url: "https://github.com/jenkinsci/github-sqs-plugin.git",
         package: "github-sqs-plugin.hpi",
         version: "a6069caf072f13178c0c83b3b95f4d6ae12caad0" }
 


### PR DESCRIPTION
For making Insights work on Ginkgo version we need to deploy discovery role to edxapp server, `SANDBOX_ENABLE_DISCOVERY ` is a variable comes from `edx-configs` and if it is set to `true` we install discovery role, this role tasks comes from `edx_django_service` role and it was needed to create new nginx template because the current template is not flexible on changing domain name and SSL cert path. that's why i ended to make new template called `discovery.j2` and it will be used when `SANDBOX_ENABLE_DISCOVERY ` is `true`
Change i made in Jenkins_master is to point to new repo because the current one points to non existence repo for `github-sqs-plugin`


Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
