### PR TITLE
set default value for EDXAPP_PLATFORM_NAME

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -89,7 +89,7 @@ NGINX_SERVER_HTML_FILES:
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     heading: 'Uh oh, we are having some server issues..'
   - file: server-maintenance.html
-    title: '{{ EDXAPP_PLATFORM_NAME }} temporarily unavailable'
+    title: '{{ EDXAPP_PLATFORM_NAME | default("Site") }} temporarily unavailable'
     msg: 'A maintenance operation is currently in progress on our system that will affect your access to our online courses.<br/><br/>If you have any questions or concerns, please contact <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     heading: 'Maintenance in Progress'


### PR DESCRIPTION
The variable is set in `playbooks/roles/edxapp/defaults/main.yml` but in the test suite, with the version of ansible used there (for the ficus branch), it appears that it is not reliably available when the nginx role runs, resulting in an exception and failed test. Eg, https://travis-ci.org/appsembler/configuration/jobs/430567280

```
TASK [nginx : Create NGINX server templates] ***********************************
task path: /edx/app/edx_ansible/edx_ansible/playbooks/roles/nginx/tasks/main.yml:300
fatal: [127.0.0.1]: FAILED! => {
    "failed": true, 
    "msg": "[{u'msg': u'If think you have encountered this message in error please let us know at <a href=\"mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}\">{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}</a>', u'img': u'{{ NGINX_SERVER_ERROR_IMG }}', u'heading': u'Uh oh, we are having some server issues..', u'file': u'rate-limit.html', u'title': u'Rate limit exceeded'}, {u'msg': u'We have been notified of the error, if it persists please let us know at <a href=\"mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}\">{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}</a>', u'img': u'{{ NGINX_SERVER_ERROR_IMG }}', u'heading': u'Uh oh, we are having some server issues..', u'file': u'server-error.html', u'title': u'Server error'}, {u'msg': u'A maintenance operation is currently in progress on our system that will affect your access to our online courses.<br/><br/>If you have any questions or concerns, please contact <a href=\"mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}\">{{ EDXAPP_TECH_SUPPORT_EMAIL|default(\"technical@example.com\") }}</a>', u'img': u'{{ NGINX_SERVER_ERROR_IMG }}', u'heading': u'Maintenance in Progress', u'file': u'server-maintenance.html', u'title': u'{{ EDXAPP_PLATFORM_NAME }} temporarily unavailable'}]: 'EDXAPP_PLATFORM_NAME' is undefined"
}

RUNNING HANDLER [nginx : restart nginx] ****************************************

RUNNING HANDLER [nginx : reload nginx] *****************************************
	to retry, use: --limit @/edx/app/edx_ansible/edx_ansible/docker/plays/jenkins_tools.retry

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=40   changed=18   unreachable=0    failed=1   
```

This doesn't seem to be an issue in production, but is breaking the tests. This just sets a default to help the test pass.
