### PR TITLE
use dict syntax for SCORM_PLAYER_LOCAL_STORAGE_ROOT

### DIFF
--- a/playbooks/roles/scorm/defaults/main.yml
+++ b/playbooks/roles/scorm/defaults/main.yml
@@ -10,8 +10,8 @@ SCORM_S3_LOGS_NOTIFY_EMAIL: dummy@example.com
 SCORM_S3_LOGS_FROM_EMAIL: dummy@example.com
 
 scorm_name: "scorm"
-scorm_asset_local_storage_path: "{{ edxapp_media_dir }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock.SCORM_PKG_STORAGE_DIR | default('scorms')}}"
-scorm_player_local_storage_root: "{{ COMMON_DATA_DIR }}/edxapp/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock.SCORM_PLAYER_LOCAL_STORAGE_ROOT|default('scormplayers') }}"
+scorm_asset_local_storage_path: "{{ edxapp_media_dir }}/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PKG_STORAGE_DIR'] | default('scorms')}}"
+scorm_player_local_storage_root: "{{ COMMON_DATA_DIR }}/edxapp/{{ EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PLAYER_LOCAL_STORAGE_ROOT'] | default('scormplayers') }}"
 
 nginx_includes_dir: "{{ nginx_app_dir }}/includes"
 


### PR DESCRIPTION
I'm not really sure about this one.

Tests on Travis are failing with an error like:

```
TASK [nginx : Copying nginx configs for [u'lms', u'cms', u'xqueue', u'certs', u'forum']] ***
failed: [127.0.0.1] (item=lms) => {"failed": true, "item": "lms", "msg": "AnsibleUndefinedVariable: 'EDXAPP_SCORM_PLAYER_LOCAL_STORAGE_ROOT' is undefined"}
failed: [127.0.0.1] (item=cms) => {"failed": true, "item": "cms", "msg": "AnsibleUndefinedVariable: 'EDXAPP_SCORM_PLAYER_LOCAL_STORAGE_ROOT' is undefined"}
changed: [127.0.0.1] => (item=xqueue)
changed: [127.0.0.1] => (item=certs)
changed: [127.0.0.1] => (item=forum)
RUNNING HANDLER [nginx : restart nginx] ****************************************
RUNNING HANDLER [nginx : reload nginx] *****************************************
	to retry, use: --limit @/edx/app/edx_ansible/edx_ansible/docker/plays/nginx.retry
PLAY RECAP *********************************************************************
127.0.0.1                  : ok=39   changed=17   unreachable=0    failed=1   
```

The thing is, there is no `EDXAPP_SCORM_PLAYER_LOCAL_STORAGE_ROOT` variable anywhere in the codebase. The closest we have is `EDXAPP_XBLOCK_SETTINGS.ScormXBlock.SCORM_PLAYER_LOCAL_STORAGE_ROOT`

I *think* we are running into a bug in the version of ansible used for the ficus tests that is causing it to parse that incorrectly. This is mostly a guess on my part. Other parts of the code access that variable as `EDXAPP_XBLOCK_SETTINGS.ScormXBlock['SCORM_PLAYER_LOCAL_STORAGE_ROOT']` and don't seem to have a problem, so I'm hoping that changing it here will avoid the bug.