### PR TITLE
bump ansible to 2.4.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.0.0
+ansible==2.4.3.0
 PyYAML==3.12
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
seeing if it's possible to upgrade this to a more recent version of ansible. The recent collectstatic tweak uses `tempfile` which apparently was introduced in ansible 2.3.