### PR TITLE
set temp staticfiles directory permission

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -228,6 +228,7 @@
     path: "{{ staticfiles_tmpdir.stdout }}"
     owner: "{{ edxapp_user }}"
     group: "{{ common_web_group }}"
+    mode:  "0755"
   when: celery_worker is not defined and not devstack
   tags:
     - gather_static_assets


### PR DESCRIPTION
Discovered this problem on a production push this morning.

`/edx/var/edxapp/staticfiles` ended up with a mode of `0700` and static files were broken.

This is because the `mktemp` that we use to create the temporary staticfiles directory defaults to `0700`. Once it is populated, we just copy it into `/edx/var/edxapp/` with its existing mode.

Basically, I missed this line in the old version: https://github.com/appsembler/configuration/blob/57f6f523aab95634560db306f04725daad91385d/playbooks/roles/edxapp/tasks/service_variant_config.yml#L206