### PR TITLE
Revert "Remove customer_theme notify 'recompile SASS'."

### DIFF
--- a/playbooks/roles/edxapp/handlers/main.yml
+++ b/playbooks/roles/edxapp/handlers/main.yml
@@ -7,3 +7,7 @@
     virtualenv: "{{ edxapp_venv_dir }}"
   environment: "{{ edxapp_environment }}"
   ignore_errors: yes
+  # this handler only works (and is only needed)
+  # on Tahoe
+  when:
+    - edx_platform_version == "appsembler/amc/master"

--- a/playbooks/roles/edxapp/tasks/customer_theme.yml
+++ b/playbooks/roles/edxapp/tasks/customer_theme.yml
@@ -15,6 +15,7 @@
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
+  notify: recompile SASS
   register: edxapp_theme_checkout
 
 - name: checkout customer override themes
@@ -29,4 +30,5 @@
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
+  notify: recompile SASS
   register: edxapp_theme_override_checkout


### PR DESCRIPTION
need to revert https://github.com/appsembler/configuration/commit/eeb2ab6e980cfc91d8235280118a2f74bc48cfc2

It appears that the recompile SASS step was removed from the `appsembler/ficus/develop` branch of edx-platform (I assume because it wasn't used on Enterprise).

The `appsembler/amc/develop` branch that Tahoe uses does still have it though: https://github.com/appsembler/edx-platform/blob/appsembler/amc/develop/openedx/core/djangoapps/appsembler/sites/management/commands/recompile_site_sass.py

And we need it to run on deploys or we end up with broken customer themes.

The problem is that we have different branches of `edx-platform` but both use the same branch of `configuration`. So I'm making this PR to restore the functionality that we need in Tahoe, but it will take some communication to figure out exactly how we want to resolve this so we don't break Enterprise deploys.

This reverts that commit and adds a conditional to the handler so it should only run on Tahoe.