### PR TITLE
(WIP) Fixups for Enterprise Hawthorn

### DIFF
--- a/playbooks/appsemblerPlaybooks/monitoring.yml
+++ b/playbooks/appsemblerPlaybooks/monitoring.yml
@@ -17,12 +17,12 @@
     - role: "{{ appsembler_roles }}/logstash"
       when: "LOGSTASH_ENABLED|default(False)"
 
-    - role: "{{ appsembler_roles }}/stackdriver"
-      when: "cloud_provider == 'gcp'"
+#    - role: "{{ appsembler_roles }}/stackdriver"
+#      when: "cloud_provider == 'gcp'"
 
     - "{{ appsembler_roles }}/monit"
 
     - "{{ appsembler_roles }}/snort"
 
-    - role: newrelic
-      when: COMMON_ENABLE_NEWRELIC
+#    - role: newrelic
+#      when: COMMON_ENABLE_NEWRELIC

--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -124,5 +124,6 @@
     mode: "0644"
   with_items: "{{ motd_files_exist.results }}"
   when:
-    - vagrant_home_dir.stat.exists == False and ansible_distribution in common_debian_variants and item.stat.exists
     - cloud_provider == "aws"
+    - not vagrant_home_dir.stat.exists|default(False)
+    - ansible_distribution in common_debian_variants and item.stat.exists

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -10,7 +10,7 @@
   register: demo_checkout
 
 - name: import demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -31,7 +31,7 @@
     demo_test_admin_and_staff_users: "{{ demo_test_and_staff_users + SANDBOX_EDXAPP_USERS }}"
 
 - name: create some test users
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}{% if item.is_staff %} --staff{% endif %}{% if item.is_superuser %} --superuser{% endif %}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}{% if item.is_staff %} --staff{% endif %}{% if item.is_superuser %} --superuser{% endif %}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -39,7 +39,7 @@
   when: demo_checkout.changed
 
 - name: enroll test users in the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -48,14 +48,14 @@
   when: demo_checkout.changed
 
 - name: add test users to the certificate whitelist
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"
   when: demo_checkout.changed
 
 - name: seed the forums for the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -482,7 +482,7 @@
     - install:oauth-credentials
 
 - name: create service worker users
-  shell: "{{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -493,7 +493,7 @@
     - manage:db
 
 - name: reindex all courses
-  shell: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -506,7 +506,7 @@
   cron:
     name: "clear expired Django sessions"
     user: "{{ edxapp_user }}"
-    job: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms clearsessions --settings={{ edxapp_settings }} >/dev/null 2>&1"
+    job: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms clearsessions --settings={{ edxapp_settings }} >/dev/null 2>&1"
     hour: "{{ EDXAPP_CLEARSESSIONS_CRON_HOURS }}"
     minute: "{{ EDXAPP_CLEARSESSIONS_CRON_MINUTES }}"
     day: "*"


### PR DESCRIPTION
I'm making a little server to test the `appsembler/hawthorn/master` branch for Enterprise deploymets:

 - https://github.com/appsembler/edx-platform/pull/282

Commit 2e61890 is a cherry pick from my upstream pull request: https://github.com/edx/configuration/pull/4812

The other commits are

 - `Disable stackdriver and NewRelic roles`: I'm not sure how to fix those two because of https://github.com/appsembler/roles/issues/50
 - `Fix an issue with Hawthorn deployment on GCP`: `cloud_provider == "aws"` needs to be checked first, otherwise it'll fail due to missing `stat` variable.

