### PR TITLE
Revert the hack for collectstatic in temp + fix create OAuth credentials

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -463,6 +463,7 @@
 
 - name: Create OAuth credentials
   shell: >
+    . {{ edxapp_app_dir }}/edxapp_env &&
     {{ edxapp_venv_bin }}/python manage.py lms --setting={{ EDXAPP_SETTINGS }} create_oauth2_client {{ item.url }} {{ item.redirect_uri }}
     {{ item.client_type }} --client_name {{ item.client_name }} --client_id {{ item.client_id }} --client_secret {{ item.client_secret }} --trusted
     chdir={{ edxapp_code_dir }}

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -192,99 +192,29 @@
   tags:
     - migrate
 
-# to avoid the running site breaking while collectstatic runs, we
-# generate a temp dir, make a new temporary configuration that points
-# STATIC_ROOT at that temp dir, runs the collectstatic to populate it,
-# then swaps in that temp dir in place of the actual staticfiles
-# directory in one quick step
-
-# this is what we should be using, but it's only available in ansible 2.3+
-# - name: Create temporary staticfiles directory
-#   tempfile:
-#     state: directory
-#     suffix: staticfiles
-#     owner: "{{ edxapp_user }}"
-#     group: "{{ common_web_group }}"
-#   register: staticfiles_tmpdir
-#   when: celery_worker is not defined and not devstack and item != "lms-preview"
-#   tags:
-#     - gather_static_assets
-#     - assets
-#     - update_lms_theme
-
-# instead, for now we have to do this:
-
-- name: Create temporary staticfiles directory
-  command: "mktemp -d"
-  register: staticfiles_tmpdir
-  when: celery_worker is not defined and not devstack
-  tags:
-    - gather_static_assets
-    - assets
-    - update_lms_theme
-
-- name: make sure it has proper ownership
+# There are problems with django collectstatic copying files.  It doesn't retain
+# last modified timestamps, but relies on those same timestamps to know if a new file
+# should be recopied.  While collectstatic --clear exists, it only clears some of the
+# files in edxapp_staticfile_dir, it leaves postprocessed or otherwise hashed files.
+# This ensures we have a totally clean directory.
+- name: Remove and recreate the staticfiles directory so nothing stale can exist
   file:
-    path: "{{ staticfiles_tmpdir.stdout }}"
-    owner: "{{ edxapp_user }}"
-    group: "{{ common_web_group }}"
-    mode:  "0755"
+      path: "{{ edxapp_staticfile_dir }}"
+      state: "{{ item }}"
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+      mode:  "0755"
   when: celery_worker is not defined and not devstack
+  with_items: ['absent', 'directory']
   tags:
     - gather_static_assets
     - assets
-    - update_lms_theme
 
-- name: "generate new {{ item }} override config"
-  template:
-    src: staticfiles_override.py.j2
-    dest: "{{ edxapp_code_dir }}/{{ item }}/envs/staticfiles_override.py"
-    owner: "{{ edxapp_user }}"
-    group: "{{ common_web_group }}"
-    mode: 0640
-  with_items: "{{ service_variants_enabled }}"
-  when: celery_worker is not defined and not devstack and item != "lms-preview"
-  tags:
-    - gather_static_assets
-    - assets
-    - update_lms_theme
-
-# Gather assets using paver
+# Gather assets using paver if possible
 - name: "gather {{ item }} static assets with paver"
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
-  environment:
-    EDX_PLATFORM_SETTINGS_OVERRIDE: "staticfiles_override"
   when: celery_worker is not defined and not devstack and item != "lms-preview"
   with_items: "{{ service_variants_enabled }}"
   tags:
     - gather_static_assets
     - assets
-    - update_lms_theme
-
-# Replace staticfiles dirs
-- name: Move staticfiles out of the way
-  command: "mv {{ edxapp_staticfile_dir }} /tmp/old_staticfiles_dir"
-  when: celery_worker is not defined and not devstack
-  tags:
-    - gather_static_assets
-    - assets
-    - update_lms_theme
-
-- name: Replace with new version of staticfiles
-  command: "mv {{ staticfiles_tmpdir.stdout }} {{ edxapp_staticfile_dir}}"
-  when: celery_worker is not defined and not devstack
-  tags:
-    - gather_static_assets
-    - assets
-    - update_lms_theme
-
-- name: "Remove {{ item }} temporary staticfiles config"
-  file:
-    path: "{{ edxapp_code_dir }}/{{ item }}/envs/staticfiles_override.py"
-    state: absent
-  with_items: "{{ service_variants_enabled }}"
-  when: celery_worker is not defined and not devstack and item != "lms-preview"
-  tags:
-    - gather_static_assets
-    - assets
-    - update_lms_themes


### PR DESCRIPTION
Revert 380c0a2d8d834f65dd3e4c808704b1ed73aeb03c and everything after:
    
   - Collectstatic in temp: https://github.com/appsembler/configuration/pull/162
   - set temp staticfiles directory permission: https://github.com/appsembler/configuration/pull/173
   - make sure /tmp/old_staticfiles_dir doesn't exist: https://github.com/appsembler/configuration/pull/175

@amirtds and @thatguynishant had issues while deploying different production deployments. The issue had a log like this:

  - [See Slack thread](https://appsembler.slack.com/archives/C9WEYL24Q/p1542899379008800).


Let's revert this, and try to pursue a more refactored fix upstream, usually we'd get more eyes to review and fresh perspective.