### PR TITLE
Fix `ImproperlyConfigured` with Boto and S3 on GCP VMs for OAuth creds step

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -463,6 +463,7 @@
 
 - name: Create OAuth credentials
   shell: >
+    . {{ edxapp_app_dir }}/edxapp_env &&
     {{ edxapp_venv_bin }}/python manage.py lms --setting={{ EDXAPP_SETTINGS }} create_oauth2_client {{ item.url }} {{ item.redirect_uri }}
     {{ item.client_type }} --client_name {{ item.client_name }} --client_id {{ item.client_id }} --client_secret {{ item.client_secret }} --trusted
     chdir={{ edxapp_code_dir }}


### PR DESCRIPTION
Was in https://github.com/appsembler/configuration/pull/180. Opening here to make the PRs atomic.

### What's This Error

Every GCP prod server has a Boto (S3) issue, Morgan and I have fixed it everywhere except for this place:


### How to Reproduce

Run the following command of a GCP VM:

```
$ ax ansible --ansible-tag=install:oauth-credentials  provision
```

It will fail due to:

```
raise ImproperlyConfigured("Could not load Boto's S3 bindings."
django.core.exceptions.ImproperlyConfigured: Could not load Boto's S3 bindings.
See https://github.com/boto/boto
```