### PR TITLE
Fixup LMS segment site variable name

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1056,7 +1056,7 @@ generic_env_config:  &edxapp_generic_env
 lms_auth_config:
   <<: *edxapp_generic_auth
   SEGMENT_KEY: "{{ EDXAPP_LMS_SEGMENT_KEY }}"
-  SEGMENT_SITE: "{{ EDXAPP_SEGMENT_SITE }}"
+  SEGMENT_SITE: "{{ EDXAPP_ENABLE_SEGMENT_SITE }}"
   OPTIMIZELY_PROJECT_ID: "{{ EDXAPP_OPTIMIZELY_PROJECT_ID }}"
   EDX_API_KEY: "{{ EDXAPP_EDX_API_KEY }}"
   VERIFY_STUDENT: "{{ EDXAPP_VERIFY_STUDENT }}"


### PR DESCRIPTION
The variable name wasn't changed, the Travis tests are failing for https://github.com/appsembler/configuration/pull/185. See the [Travis log for more details](https://travis-ci.org/appsembler/configuration/jobs/463231424) specifically `'EDXAPP_SEGMENT_SITE' is undefined"}`:

```

TASK [edxapp : create application and auth config] *****************************
changed: [localhost] => (item=[u'lms', u'env'])
failed: [localhost] (item=[u'lms', u'auth']) => {"failed": true, "item": ["lms", "auth"], "msg": "AnsibleUndefinedVariable: {u'SEGMENT_KEY': u'{{ EDXAPP_LMS_SEGMENT_KEY }}', u'AWS_QUERYSTRING_AUTH': u'{{ EDXAPP_AWS_QUERYSTRING_AUTH }}', u'SWIFT_USE_TEMP_URLS
...
u'SOCIAL_AUTH_SAML_SP_PRIVATE_KEY': u'{{ EDXAPP_SOCIAL_AUTH_SAML_SP_PRIVATE_KEY }}', u'CREDIT_PROVIDER_SECRET_KEYS': u'{{ EDXAPP_CREDIT_PROVIDER_SECRET_KEYS }}', u'EMAIL_HOST_USER': u'{{ EDXAPP_EMAIL_HOST_USER }}', u'SWIFT_TENANT_ID': u'{{ EDXAPP_SWIFT_TENANT_ID }}'}:
...
'EDXAPP_SEGMENT_SITE' is undefined"}
changed: [localhost] => (item=[u'cms', u'env'])
changed: [localhost] => (item=[u'cms', u'auth'])
	to retry, use: --limit @/home/travis/build/appsembler/configuration/playbooks/edx-east/edxapp.retry
PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```


### Follow up Question

 - [ ] @melvinsoft Why are we putting this `EDXAPP_ENABLE_SEGMENT_SITE` in `lms_auth_config`, shouldn't this variable be a feature flag?

Please let me know if I'm misunderstanding something.

I can fix that and create the needed `edx-platform`/`edx-configs`/`configuration` PRs if needed. But for now let's get this one merged first.