### PR TITLE
remove SEGMENT_SITE from CMS auth

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1130,7 +1130,6 @@ lms_env_config:
 cms_auth_config:
   <<: *edxapp_generic_auth
   SEGMENT_KEY: "{{ EDXAPP_CMS_SEGMENT_KEY }}"
-  SEGMENT_SITE: "{{ EDXAPP_ENABLE_SEGMENT_SITE }}"
   MODULESTORE:
     default:
         ENGINE: 'xmodule.modulestore.mixed.MixedModuleStore'


### PR DESCRIPTION
Since the CMS isn't microsite aware, trying to get the site settings is causing problems. CMS events is not a requirement in this phase of the implementation. Let's remove it from the CMS auth JSON.
