### PR TITLE
set correct STATIC_ROOT for cms staticfiles override

### DIFF
--- a/playbooks/roles/edxapp/templates/staticfiles_override.py.j2
+++ b/playbooks/roles/edxapp/templates/staticfiles_override.py.j2
@@ -1,3 +1,8 @@
 from .{{ edxapp_settings }} import *
 
+{% if item == 'cms' %}
+# cms uses a hashed directory to bust caches
+STATIC_ROOT = "{{ staticfiles_tmpdir.stdout }}" + "/" + EDX_PLATFORM_REVISION
+{% else %}
 STATIC_ROOT = "{{ staticfiles_tmpdir.stdout }}"
+{% endif %}


### PR DESCRIPTION
It turns out that the cms config sets up `STATIC_ROOT` differently, putting the git revision hash into it. That explains the hashed directory. This PR does the same thing on the cms settings override. This should fix the issue with Studio styles getting lost on deploys.

At some point, I'd still like to understand why it was designed this way. It effectively duplicates all the static files into two different directories in a very confusing and surprising way. I think the cache busting approach also potentially doesn't always work as planned (eg, theme changes don't change the `edx-platform` hash).