### PR TITLE
Add aws role to amc

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -46,6 +46,7 @@
   roles:
     - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: sudo
+    - role: aws
     - custom_domains # This gets a list of custom domains
     - role: "{{ appsembler_roles }}/gcsfuse"
     - mysql_init


### PR DESCRIPTION
We're missing this peace to get our tracking in S3. 

Adding this role to our `amc` playbook will do the job. It is safe, but we need to merge the companion edx-configs PR: https://github.com/appsembler/edx-configs/pull/507

Adding that variable `cloud_provider: "gcp"` will only run this two tasks: https://github.com/appsembler/configuration/blob/appsembler/ficus/master/playbooks/roles/aws/tasks/main.yml#L75