### PR TITLE
edxapp role create any database cache tables

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -356,6 +356,18 @@
     - service_variant_config
     - deploy
 
+# generate any declared database cache
+# tables (will make in default db)
+- name: create database cache tables
+  django_manage:
+    app_path: "{{ edxapp_code_dir }}"
+    command: "lms createcachetable"
+    settings: "{{ EDXAPP_SETTINGS }}"
+    virtualenv: "{{ edxapp_venv_dir }}"
+  environment: "{{ edxapp_environment }}"
+  ignore_errors: yes
+
+
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts
   # the services if any of the configurations


### PR DESCRIPTION
Adds a task in edxapp role to create any declared cache tables with `manage.py lms createcachetable`.  If none are specified in given settings file, nothing will happen.  This will create all specified cache tables based on settings (i.e., any using `django.core.cache.db.DatabaseCache` as a backend), and will not overwrite if they already exist.