### PR TITLE
Use Mongo v3.2.x for Tahoe Hawthorn

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -59,7 +59,7 @@
       - lms
     - role: mysql
       when: EDXAPP_MYSQL_HOST == 'localhost'
-    - role: mongo
+    - role: mongo_3_2
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     # Do we need need edxapp 2 times here????
     - { role: 'edxapp', celery_worker: True }


### PR DESCRIPTION
Well, we [can't upload files in Open edX (Trello)](https://trello.com/c/qovYaOyj/3860-0-hawthorn-staging-testing-file-uploads-dont-work) and [Sentry shows that it's an OperationFailure](https://sentry.io/organizations/appsembler/issues/967058574/?project=145493&query=is%3Aunresolved&statsPeriod=14d&utc=false).

After digging I've found that this question in [Stackoverflow recommends getting MongoDB 3.2 to fix the issue](https://stackoverflow.com/a/44303859/161278). Apparently that's what [edX uses anyway for the vanilla edx_sandbox.yml in Hawthorn](https://github.com/edx/configuration/blob/open-release/hawthorn.master/playbooks/edx_sandbox.yml#L49-L50).

Sounds all clean and nice with references, just like a scientific paper. But will it "just" work in practice? I don't know. I really hope that we don't end up breaking the Staging for a week because of this upgrade, since J'aime is depending on it now for mobile testing.