### PR TITLE
playbook for running credentials extensions commands

### DIFF
--- a/playbooks/appsemblerPlaybooks/credentials_extensions.yml
+++ b/playbooks/appsemblerPlaybooks/credentials_extensions.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Run custom credentials setup
+  hosts: edxapp-server
+  become: True
+  become_method: sudo
+  gather_facts: True
+  tasks:
+    - include_vars: "../roles/common_vars/defaults/main.yml"
+      tags:
+        - install
+        - credentials:config
+    - include_vars: "../roles/edxapp/defaults/main.yml"
+      tags: 
+        - install
+        - credentials:config    
+    - name: Run custom course certificates setup
+      become_user: "{{ edxapp_user }}"
+      django_manage:
+          command: "cms {{item}}"
+          app_path: "{{ edxapp_code_dir }}"
+          pythonpath: "{{ edxapp_code_dir }}"
+          virtualenv: "{{ edxapp_venv_dir }}"
+          settings: "{{ EDXAPP_SETTINGS }}"
+      environment: "{{ edxapp_environment }}"
+      with_items:
+        - "create_course_certificates --noinput --all"
+      run_once: True
+      tags:
+        - install
+        - credentials:config


### PR DESCRIPTION
For inclustion in `customer-post.yml` playbooks, will run management commands from appsembler_credentials_extensions, if needed.  

e.g., see pennstate-ginkgo configs

`create_course_certificates` creates and activates a course certificate "in Studio" using configuration from CMS environment. 

