### PR TITLE
remove hash from staticfiles override

### DIFF
--- a/playbooks/roles/edxapp/templates/staticfiles_override.py.j2
+++ b/playbooks/roles/edxapp/templates/staticfiles_override.py.j2
@@ -1,8 +1,7 @@
 from .{{ edxapp_settings }} import *
 
 {% if item == 'cms' %}
-# cms uses a hashed directory to bust caches
-STATIC_ROOT = "{{ staticfiles_tmpdir.stdout }}" + "/" + EDX_PLATFORM_REVISION
+STATIC_ROOT = "{{ staticfiles_tmpdir.stdout }}" + "/studio"
 {% else %}
 STATIC_ROOT = "{{ staticfiles_tmpdir.stdout }}"
 {% endif %}


### PR DESCRIPTION
Hawthorn no longer uses the `EDX_PLATFORM_REVISION` hash in the CMS `STATIC_ROOT` (see: https://github.com/edx/edx-platform/pull/16819) instead just using `/studio` for the CMS.

That means that when we override the config (for the zero-downtime deploys), we need to match that change.

This should fix the problems we are having with hawthorn deploys breaking and requiring a manual `update-static-assets` every time so it doesn't break on the missing `webpack-stats.json`.
