### PR TITLE
Really use mongo 3.2 for Tahoe Hawthorn

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -6,7 +6,7 @@
   become_method: sudo
   gather_facts: True
   roles:
-    - mongo_3_0
+    - mongo_3_2
 
 - name: Configure shared services (es and memcached)
   hosts: services


### PR DESCRIPTION
Because the previous one #216 really only worked for Single Server installations, which we never used for Hawthorn.

This is the bit that I've been missing :face_with_head_bandage: instead of [the mess that I've created](https://appsembler.slack.com/archives/CCT7XSP9D/p1555368516039200).