### PR TITLE
Appsembler/ficus/edxapp create cachetables

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -358,6 +358,18 @@
     - service_variant_config
     - deploy
 
+# generate any declared database cache
+# tables (will make in default db)
+- name: create database cache tables
+  django_manage:
+    app_path: "{{ edxapp_code_dir }}"
+    command: "lms createcachetable"
+    settings: "{{ EDXAPP_SETTINGS }}"
+    virtualenv: "{{ edxapp_venv_dir }}"
+  environment: "{{ edxapp_environment }}"
+  ignore_errors: yes
+
+
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts
   # the services if any of the configurations

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -368,7 +368,10 @@
     virtualenv: "{{ edxapp_venv_dir }}"
   environment: "{{ edxapp_environment }}"
   ignore_errors: yes
-
+  tags:
+      - install
+      - install:code
+      - install:app-requirements
 
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts


### PR DESCRIPTION
Run `./manage.py lms createcachetable` as part of edxapp deploy tasks, so that tables in default db are created for any specified database-backed caches.  Specifically, this is used to store Badgr API auth and refresh tokens for badges app.