### PR TITLE
nginx: Empty the robots.txt file when there are no rules (upstream cherry-pick)

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -129,7 +129,6 @@
     group: "{{ common_web_user }}"
     mode: 0644
   notify: reload nginx
-  when: NGINX_ROBOT_RULES|length > 0
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -121,7 +121,7 @@
     - install
     - install:configuration
 
-- name: Create robot rules when needed
+- name: Create robot rules
   template:
     src: "edx/app/nginx/robots.txt.j2"
     dest: "{{ nginx_app_dir }}/robots.txt"
@@ -129,17 +129,7 @@
     group: "{{ common_web_user }}"
     mode: 0644
   notify: reload nginx
-  when: NGINX_ROBOT_RULES|length
-  tags:
-    - install
-    - install:configuration
-
-- name: Remove robots file if not needed
-  file:
-    path: "{{ nginx_app_dir }}/robots.txt"
-    state: absent
-  notify: reload nginx
-  when: not NGINX_ROBOT_RULES|length
+  when: NGINX_ROBOT_RULES|length > 0
   tags:
     - install
     - install:configuration


### PR DESCRIPTION
Long story short, this reverts our version of the solution (https://github.com/appsembler/configuration/pull/195) in favor of the upstream version (https://github.com/edx/configuration/pull/5013).

More details are available in the pull requests.