### PR TITLE
Tahoe: use nginx_lms_extra_locations for custom domains

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-common-settings.j2
@@ -224,6 +224,10 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
 
   {% include "extra_locations_lms.j2" ignore missing %}
 
+  {% if nginx_lms_extra_locations != "" %}
+    {{ nginx_lms_extra_locations }}
+  {% endif %}
+
   {% if EDXAPP_XBLOCK_SETTINGS.get('ScormXBlock', False) %}
     # asterisk needed so it doesn't break if the file doesn't exist
     include {{nginx_app_dir}}/includes/scorm_extra_locations_lms*;


### PR DESCRIPTION
### Why
RedisLabs wants to show only the RedisLabs favicon, and not edX's.

### Technical Details
Same as https://github.com/appsembler/configuration/pull/95 but for Tahoe custom domains. 

This needed to make https://university.redislabs.com/favicon.ico returns 404 just like http://cybereason.tahoe.appsembler.com/favicon.ico is doing.

This is a continuation to https://github.com/appsembler/edx-configs/pull/640

### Trello Card
![](https://camo.githubusercontent.com/193766a3b9959c5f4ed5cd8cf3251d015e839d51/68747470733a2f2f6769746875622e7472656c6c6f2e73657276696365732f696d616765732f6d696e692d7472656c6c6f2d69636f6e2e706e67) [(2) Fix specific cases where browser displays Open edX logo as favicon](https://trello.com/c/oxnXjXv2/4265-2-fix-specific-cases-where-browser-displays-open-edx-logo-as-favicon)