### PR TITLE
Tahoe remove pdf certs from servers

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -98,17 +98,3 @@
     - role: custom_domains # This gets the list of domains
       when: nginx_enable_custom_domains|default(False)
     - { role: "{{ appsembler_roles }}/letsencrypt", letsencrypt_webserver: "" }
-
-# must come after xqueue running
-- name: Install certs
-  hosts: "edx"
-  become: True
-  become_method: sudo
-  gather_facts: True
-  vars:
-    migrate_db: "yes"
-  roles:
-    - certs
-    - role: nginx
-      nginx_sites:
-      - certs


### PR DESCRIPTION
In Tahoe we use HTML certificates, which is included in the edx-platform code. We don't need the legacy PDF certs app.

As we know this app was the cause of the outage, people was trying to generate example certs, and XQueue was trying to generate them in an endless loop, creating random folders in `/tmp` until we run out of inodes on the both servers.

This PR removes the app from the installation process.