### PR TITLE
Tahoe: refresh customer site styles on each deployment

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -20,6 +20,10 @@ EDXAPP_APPSEMBLER_FEATURES: {
   TMP: None
 }
 
+# Enables the "Update Tahoe site-specific styles" task.
+# This variable should be only enabled for Tahoe deployments.
+EDXAPP_TAHOE_REBUILD_SITE_STYLES: false
+
 # Bucket used for xblock file storage
 EDXAPP_XBLOCK_FS_STORAGE_BUCKET: "None"
 EDXAPP_XBLOCK_FS_STORAGE_PREFIX: "None"

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -295,6 +295,20 @@
     - assets
     - update_lms_theme
 
+- name: "Update Tahoe site-specific styles"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python manage.py lms save_all_sites --settings={{ edxapp_settings }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  when:
+   - celery_worker is not defined
+   - not devstack
+   - EDXAPP_TAHOE_REBUILD_SITE_STYLES
+  tags:
+    - gather_static_assets
+    - assets
+    - update_lms_theme
+
 # make sure the old staticfiles backup dir isn't lingering around.
 - name: Remove old staticfiles backup dir
   file:

--- a/playbooks/roles/supervisor/defaults/main.yml
+++ b/playbooks/roles/supervisor/defaults/main.yml
@@ -44,8 +44,8 @@ supervisor_service_user: "{{ common_web_user }}"
 supervisor_version: 3.2.3
 
 supervisor_pip_pkgs:
-  - boto=="{{ common_boto_version }}"
-  - python-simple-hipchat
+  - "boto=={{ common_boto_version }}"
+  - "python-simple-hipchat"
 
 supervisor_spec:
   - service: edxapp


### PR DESCRIPTION
Tahoe sites needs a CSS-refresh on every deployment. We have made and used the [`save_all_sites`](https://github.com/appsembler/edx-platform/blob/847d67be04f3e39aa5a03a5404a7e0b1ff1155bd/openedx/core/djangoapps/appsembler/sites/management/commands/save_all_sites.py#L7-L20) command to do this during the Hawthorn upgrade but we haven't included as a regular step in our deployment playbooks.

[RED-118](https://appsembler.atlassian.net/browse/RED-118) a re-occurring issue and this pull request solves it -- hopefully for good.

### TODO

 - [x] Get a review
 - [x] Get the https://github.com/appsembler/edx-configs/pull/701 pull request merged
 - [x] Fix the broken tests
 - [ ] Merge and test via CloudBuild on Staging.