### PR TITLE
Add support to Mongo atlas

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1069,7 +1069,7 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
-  authSource: {{ EDXAPP_MONGO_AUTH_SOURCE }} # Needed for mongo atlas
+  authSource: "{{ EDXAPP_MONGO_AUTH_SOURCE }}" # Needed for mongo atlas
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1052,7 +1052,7 @@ edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
     ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
     ssl_certfile: "{{ EDXAPP_MONGO_SSL_CLIENT_CERT_PATH }}"
     ssl_ca_certs: "{{ EDXAPP_MONGO_SSL_CA_CERT_PATH }}"
-    authSource: {{ EDXAPP_MONGO_AUTH_SOURCE }}
+    authSource: "{{ EDXAPP_MONGO_AUTH_SOURCE }}"
 
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -83,6 +83,7 @@ EDXAPP_MONGO_PORT: 27017
 EDXAPP_MONGO_USER: 'edxapp'
 EDXAPP_MONGO_DB_NAME: 'edxapp'
 EDXAPP_MONGO_USE_SSL: False
+EDXAPP_MONGO_AUTH_SOURCE: "{{ EDXAPP_MONGO_DB_NAME }}"
 
 EDXAPP_MONGO_SSL_CLIENT_KEY: ""
 EDXAPP_MONGO_SSL_CLIENT_CERT: ""
@@ -1051,6 +1052,7 @@ edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
     ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
     ssl_certfile: "{{ EDXAPP_MONGO_SSL_CLIENT_CERT_PATH }}"
     ssl_ca_certs: "{{ EDXAPP_MONGO_SSL_CA_CERT_PATH }}"
+    authSource: {{ EDXAPP_MONGO_AUTH_SOURCE }}
 
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"
@@ -1067,6 +1069,7 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
+  authSource: {{ EDXAPP_MONGO_AUTH_SOURCE }} # Needed for mongo atlas
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -21,6 +21,7 @@ FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
 FORUM_MONGO_USE_SSL: false
 FORUM_MONGO_SSL_VERIFY: true
+FORUM_MONGO_AUTH_SOURCE: "{{ FORUM_MONGO_DATABASE }}"
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
 FORUM_RACK_ENV: "development"
@@ -61,6 +62,7 @@ forum_base_env: &forum_base_env
   MONGOHQ_URL: "{{ FORUM_MONGO_URL }}"
   MONGOID_USE_SSL: "{{ FORUM_MONGO_USE_SSL }}"
   MONGOID_SSL_VERIFY: "{{ FORUM_MONGO_SSL_VERIFY }}"
+  MONGOID_AUTH_SOURCE: "{{ FORUM_MONGO_AUTH_SOURCE }}"
   HOME: "{{ forum_app_dir }}"
   NEW_RELIC_ENABLE: "{{ FORUM_NEW_RELIC_ENABLE }}"
   NEW_RELIC_APP_NAME: "{{ FORUM_NEW_RELIC_APP_NAME }}"


### PR DESCRIPTION
Mongo Atlas, the future Mongo database hosted service for Tahoe has a big difference with other providers like Compose.io (current provider) and self hosted mongo. The difference is that database users (`edxapp` and `cs_comment_service` must be live inside the admin database and not inside their own databases.

In order to avoid an authentication failure, we need to tell pymongo, against with database to authenticate in the connection parameters with the `authSource` parameter: [Mongo doc](https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource)

All this must still work work for enteprise deployments, since if not `auth_source` is specified  the ansible default will fallback to the database name, which is where mongo will try to authenticate anyway.
