### PR TITLE
Remove edX Notes API from amc playbook

### DIFF
--- a/playbooks/amc.yml
+++ b/playbooks/amc.yml
@@ -67,7 +67,6 @@
     - amc
     #- analytics_api
     #- insights
-    - edx_notes_api
     #- demo
     - oauth_client_setup
     - oraclejdk


### PR DESCRIPTION
Starting today, edx_notes_api role started to throw an error and blocking us from deploy to staging and prod:
```
stderr: Could not find a version that satisfies the requirement djangorestframework==3.10.3 (from -r /edx/app/edx_notes_api/edx_notes_api/requirements/base.txt 
```
We don't use notes in Tahoe, is pointing to master, not even to a named release. Rather than investing time into fixing this, I'd say let's remove it, until if at some point we decide to start using it.