### PR TITLE
Allow config of Celery worker prefetch optimization (default|fair)

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -638,31 +638,38 @@ EDXAPP_CELERY_WORKERS:
     service_variant: cms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: default
     service_variant: cms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: high
     service_variant: cms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: low
     service_variant: lms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: default
     service_variant: lms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: high
     service_variant: lms
     concurrency: 1
     monitor: True
+    prefetch_optimization: default
   - queue: high_mem
     service_variant: lms
     concurrency: 1
     monitor: False
     max_tasks_per_child: 1
+    prefetch_optimization: default
 EDXAPP_RECALCULATE_GRADES_ROUTING_KEY: 'edx.lms.core.default'
 EDXAPP_POLICY_CHANGE_GRADES_ROUTING_KEY: 'edx.lms.core.default'
 EDXAPP_BULK_EMAIL_ROUTING_KEY_SMALL_JOBS: 'edx.lms.core.low'

--- a/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/workers.conf.j2
@@ -7,7 +7,7 @@ directory={{ edxapp_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
-command={{ edxapp_app_dir }}/worker.sh {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
+command={{ edxapp_app_dir }}/worker.sh {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '-O ' + w.prefetch_optimization if w.prefetch_optimization is defined else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
 ; Set autorestart to `true`. The default value for autorestart is `unexpected`, but celery < 4.x will exit


### PR DESCRIPTION
https://celery.readthedocs.io/en/latest/userguide/optimizing.html#prefork-pool-prefetch-settings

Set to 'fair' if long-running tasks are blocking subsequent tasks,
even when using multiplel concurrent processes

I'm making this PR to our fork just for Hawthorn but have also opened a PR against edx/master
https://github.com/edx/configuration/pull/5590  ... there have been some other changes in the affected files since Hawthorn.