### PR TITLE
Restart celery beat on edx deploy

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -402,6 +402,22 @@
   tags:
     - manage
 
+- name: restart celery beat lms process
+  supervisorctl:
+    name: lms_celerybeat
+    supervisorctl_path: "{{ supervisor_ctl }}"
+    config: "{{ supervisor_cfg }}"
+    state: restarted
+  when: celery_worker is defined and not disable_edx_services and EDXAPP_CELERY_BEAT_LMS_ENABLED
+
+- name: restart celery beat cms process
+  supervisorctl:
+    name: cms_celerybeat
+    supervisorctl_path: "{{ supervisor_ctl }}"
+    config: "{{ supervisor_cfg }}"
+    state: restarted
+  when: celery_worker is defined and not disable_edx_services and EDXAPP_CELERY_BEAT_CMS_ENABLED
+
 - name: create symlinks from the venv bin dir and repo dir
   file:
     src: "{{ item }}"


### PR DESCRIPTION
We found this problem with figures, even if we change the pipeline schedule the change wasn't applied, @thraxil found the problem last time.

The two tasks added restart the celery beat process on deploy, if they are enabled.