### PR TITLE
Remove gcsfuse for standalone enterprise tire

### DIFF
--- a/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
+++ b/playbooks/appsemblerPlaybooks/ginkgo_enterprise.yml
@@ -58,8 +58,6 @@
     - role: nginx
       nginx_sites: []
       tags: ['nginx_role']
-    - role: "{{ appsembler_roles }}/gcsfuse"
-      when: "cloud_provider == 'gcp'"
     - role: "{{ appsembler_roles }}/letsencrypt"
       when: letsencrypt_certs | length
     - role: "{{ appsembler_roles }}/sshguard"


### PR DESCRIPTION
`gcsfuse` role used only for enterprise tire and ASU is our only enterprise tire standalone customer and we are not using `gcsfuse` to mount a storage bucket to use Let’s encrypt behind a load balancer (we are not using Letsencrypt and the  SSL connection is terminating at Loadbalancer level). Having `gcsfuse`in the playbook is causing error during deployments for ASU prod.
For more info: https://appsembler.atlassian.net/browse/BLACK-503?atlOrigin=eyJpIjoiNmQ1MWNiMTk1NTY3NGNiMDhhNjExZDlkMDc5ZWRiYjAiLCJwIjoiaiJ9

---

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] Devops team member has commented with :+1:
