### PR TITLE
Priodically build amc docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,13 @@ script:
 # our hawthorn image
 after_success:
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "appsembler/hawthorn/master" ]]; then
-      docker login -u $DOCKERUSER -p $DOCKERPASSWORD ;
-      travis_wait 50 docker build -f docker/build/edxapp/Dockerfile . -t appsembler/edxapp:latest ;
-      docker push appsembler/edxapp:latest ;
+    docker login -u $DOCKERUSER -p $DOCKERPASSWORD ;
+    travis_wait 50 docker build -f docker/build/edxapp/Dockerfile . -t appsembler/edxapp:latest ;
+    docker push appsembler/edxapp:latest ;
+    fi
+
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "appsembler/hawthorn/master" ]]; then
+    docker login -u $DOCKERUSER -p $DOCKERPASSWORD ;
+    travis_wait 50 docker build -f docker/build/amc-frontend/Dockerfile . -t appsembler/amc-frontend:latest ;
+    docker push appsembler/amc-frontend:latest ;
     fi

--- a/docker/build/amc-frontend/Dockerfile
+++ b/docker/build/amc-frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10
+
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    curl
+
+RUN which yarn  # Make sure yarn is installed
+
+RUN mkdir -p /opt/amc/frontend
+WORKDIR /opt/amc/frontend

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -5,6 +5,7 @@ aws_plays_paths:
 docker_plays_paths:
   - docker/plays
 weights:
+  - amc-frontend: 2  # Appsembler: Omar: Setting value to a dummy 2 without really caring about it.
   - discovery: 6
   - go-agent: 3
   - go-server: 5


### PR DESCRIPTION
### Overview
We've been hosting our Docker images on `grc.io` which I don't like to have it there since it complicates our setup. I'd like to have all of our Docker images hosted on Docker Hub and public to make `$ make pull` actually work flawlessly.

### What about AMC Backend?
I'd like to copy the following from AMC:

 - The requirements file: https://github.com/appsembler/amc/tree/develop/requirements
 - The Dockefile for backend

and put it in this repository.

#### What about security risks?
In my opinion there's no additional risk of opening up such requirements because most of our infrastructure is public anyway.

### TODO

 - [x] Get approvals from Anders
 - [x] Create Docker Hub repos
 - [x] Build the frontend docker image

I'll follow up with another PR for backend.
