### PR TITLE
Add appsembler.txt requirement file to edxapp

### DIFF
--- a/playbooks/roles/edxapp/vars/devstack.yml
+++ b/playbooks/roles/edxapp/vars/devstack.yml
@@ -7,3 +7,4 @@ development_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/develop
 edxapp_requirements_files:
   - "{{ custom_requirements_file }}"
   - "{{ development_requirements_file }}"
+  - "{{ edxapp_code_dir }}/requirements/edx/appsembler.txt"


### PR DESCRIPTION
So backports.tempfile is added to devstack all the time, otherwise we need to do a `paver install_prereqs` after every devstack restart. 