### PR TITLE
edxapp task to create any defined database cache tables 

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -372,8 +372,8 @@
     settings: "{{ EDXAPP_SETTINGS }}"
     virtualenv: "{{ edxapp_venv_dir }}"
   environment: "{{ edxapp_environment }}"
-  ignore_errors: yes
-
+  ignore_errors: true
+  run_once: true
 
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -363,6 +363,18 @@
     - service_variant_config
     - deploy
 
+# generate any declared database cache
+# tables (will make in default db)
+- name: create database cache tables
+  django_manage:
+    app_path: "{{ edxapp_code_dir }}"
+    command: "lms createcachetable"
+    settings: "{{ EDXAPP_SETTINGS }}"
+    virtualenv: "{{ edxapp_venv_dir }}"
+  environment: "{{ edxapp_environment }}"
+  ignore_errors: yes
+
+
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts
   # the services if any of the configurations

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -372,7 +372,6 @@
     settings: "{{ EDXAPP_SETTINGS }}"
     virtualenv: "{{ edxapp_venv_dir }}"
   environment: "{{ edxapp_environment }}"
-  ignore_errors: true
   run_once: true
 
   # call supervisorctl update. this reloads


### PR DESCRIPTION
Runs `./manage.py lms createcachetable` on one edxapp host.  That command will generate any tables in the db necessary for any Django db cache tables defined in installed Django apps.