### PR TITLE
remove celerybeat limit

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -447,7 +447,6 @@
     state: restarted
   when:
     - celery_worker is defined and not disable_edx_services and EDXAPP_CELERY_BEAT_LMS_ENABLED
-    - inventory_hostname == ansible_play_hosts_all[0]   # Avoid duplicate scheduling
 
 - name: restart celery beat cms process
   supervisorctl:
@@ -457,7 +456,6 @@
     state: restarted
   when:
     - celery_worker is defined and not disable_edx_services and EDXAPP_CELERY_BEAT_CMS_ENABLED
-    - inventory_hostname == ansible_play_hosts_all[0]  # Avoid duplicate scheduling
 
 - name: create symlinks from the venv bin dir and repo dir
   file:

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -113,7 +113,6 @@
     - install:celerybeat
   when:
    - EDXAPP_CELERY_BEAT_LMS_ENABLED or EDXAPP_CELERY_BEAT_CMS_ENABLED
-   - inventory_hostname == ansible_play_hosts_all[0]  # Avoid duplicate scheduling
 
 - name: add gunicorn configuration files
   template:
@@ -170,7 +169,6 @@
   when: 
     - celery_worker is not defined and not disable_edx_services
     - EDXAPP_CELERY_BEAT_LMS_ENABLED or EDXAPP_CELERY_BEAT_CMS_ENABLED
-    - inventory_hostname == ansible_play_hosts_all[0]  # Avoid duplicate scheduling
   tags:
     - install
     - install:configuration


### PR DESCRIPTION
no longer needed on Tahoe since celery is not running on edxapp
servers and we only have one worker
