### PR TITLE
Wow that we have serial runs, execute cd command in first server pass

### DIFF
--- a/playbooks/roles/custom_domains/tasks/main.yml
+++ b/playbooks/roles/custom_domains/tasks/main.yml
@@ -13,7 +13,7 @@
     var: edxapp_code_dir
 - debug:
     var: groups
-    
+
 - name: Fetch custom domains list
   become_user: "{{ edxapp_user }}"
   shell: >
@@ -21,7 +21,7 @@
     chdir={{ edxapp_code_dir }}
   register: custom_domains_cmd
   run_once: True
-  delegate_to: "{{ groups['edx'][1] }}"
+  delegate_to: "{{ groups['edx'][0] }}"
   tags:
     - custom_domains
     - custom_domains:get_domains


### PR DESCRIPTION
@thraxil I know you changed the `delegate_to` from 0 to 1 in the following PR.

https://github.com/appsembler/configuration/pull/207/files

but now that conflict with the `serial: 1` directive, because on fresh servers, it'll try to run an edxapp command in server 1 while is still empty and clean. 

