### PR TITLE
pass lms, cms extra location and http extra to custom domains generat…

### DIFF
--- a/playbooks/roles/edx_ansible/templates/server_vars.j2
+++ b/playbooks/roles/edx_ansible/templates/server_vars.j2
@@ -17,6 +17,10 @@ letsencrypt_alternative_acme_folder: "{{ letsencrypt_alternative_acme_folder }}"
 letsencrypt_webroot: "{{ letsencrypt_webroot }}"
 letsencrypt_webuser: "{{ letsencrypt_webuser }}"
 letsencrypt_execute_for_single_domain: true
+nginx_lms_extra_locations: {{ nginx_lms_extra_locations }}
+nginx_lms_extra_http: {{ nginx_lms_extra_http }}
+nginx_cms_extra_locations: {{ nginx_cms_extra_locations }}
+nginx_cms_extra_http: {{ nginx_cms_extra_http }}
 
 # Cert agent vars
 # TODO


### PR DESCRIPTION
While I work on SCORM XBlock I found this problem, i'm not going to go deeper in the SCORM work, but in order to make SCORM content work, we need to write an extra http location in the Nginx configuration for the lms and the cms. 

We have the machinery in place to do it in our configuration playbooks, here are the four variables that make it possible: https://github.com/appsembler/configuration/blob/6bdb7f2574960a1f12fd7e6cc2f2e08193b50556/playbooks/roles/nginx/defaults/main.yml#L202-L205

Those variables are then used in the Ansible templates to generate the Nginx configuration for the lms and the cms, here is the lms example: https://github.com/appsembler/configuration/blob/6bdb7f2574960a1f12fd7e6cc2f2e08193b50556/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2#L337-L339
and https://github.com/appsembler/configuration/blob/6bdb7f2574960a1f12fd7e6cc2f2e08193b50556/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2#L348-L350
You can find the same code in the [cms template](https://github.com/appsembler/configuration/blob/appsembler/ficus/master/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2#L157)

The problem is currently happening in custom domains, when a site uses a custom domain, an specific nginx conf is generated for that site. This specific configuration is generated by the [Cert Agent](https://github.com/appsembler/tahoe_cert_agent) running an Ansible command, this commands runs the Nginx role as part of the playbook, and generates the configuration using a different Ansible template and using an Ansible generate server-vars file. 

The problem is: the alternative Nginx templates support the extra locations and extra http variables, but we're not passing them, this change is over the server-vars template, so when the Cert Agent Ansible commands run, it can find the extra locations and extra http while generating the site custom domain Nginx config.