### PR TITLE
fix certagent server vars variables

### DIFF
--- a/playbooks/roles/edx_ansible/templates/server_vars.j2
+++ b/playbooks/roles/edx_ansible/templates/server_vars.j2
@@ -6,6 +6,16 @@
 # not been overwritten in edx-configs server-vars.yml because the templating
 # will fail otherwise
 
+# SCORM CORS
+EDXAPP_AWS_S3_CUSTOM_DOMAIN: "{{ EDXAPP_AWS_S3_CUSTOM_DOMAIN | default("") }}"
+TAHOE_SCORM_XBLOCK_ROOT_DIR: "{{ TAHOE_SCORM_XBLOCK_ROOT_DIR | default("") }}"
+
+# nging vars
+nginx_lms_specific_extra_locations: "{{ nginx_lms_specific_extra_locations | default("") }}"
+nginx_lms_specific_extra_http: "{{ nginx_lms_specific_extra_http | default("") }}"
+nginx_cms_specific_extra_locations: "{{ nginx_cms_specific_extra_locations | default("") }}"
+nginx_cms_specific_extra_http: "{{ nginx_cms_specific_extra_http | default("") }}"
+
 # letsencrypt vars
 nginx_enable_custom_domains: "{{ nginx_enable_custom_domains }}"
 letsencrypt_email: "{{ letsencrypt_email }}"
@@ -17,10 +27,7 @@ letsencrypt_alternative_acme_folder: "{{ letsencrypt_alternative_acme_folder }}"
 letsencrypt_webroot: "{{ letsencrypt_webroot }}"
 letsencrypt_webuser: "{{ letsencrypt_webuser }}"
 letsencrypt_execute_for_single_domain: true
-nginx_lms_extra_locations: {{ nginx_lms_extra_locations }}
-nginx_lms_extra_http: {{ nginx_lms_extra_http }}
-nginx_cms_extra_locations: {{ nginx_cms_extra_locations }}
-nginx_cms_extra_http: {{ nginx_cms_extra_http }}
+
 
 # Cert agent vars
 # TODO


### PR DESCRIPTION
This is a follow up of: https://github.com/appsembler/configuration/pull/332

We were bringing the wrong variables to this server vars template. In addition, since the nginx location need `EDXAPP_AWS_S3_CUSTOM_DOMAIN` and `TAHOE_SCORM_XBLOCK_ROOT_DIR` we need to bring them here too.