### PR TITLE
downgrade urllib3

### DIFF
--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -147,3 +147,18 @@
     - service: mysql
       enabled: "{{ BACKUPS_MYSQL }}"
   tags: ['backups']
+
+# one of the system-wide pip installs that runs at some point previous
+# to install libraries upgrades urllib3 to a version that breaks
+# ansible on subsequent deploys.
+# See: https://appsembler.atlassian.net/wiki/spaces/ED/pages/390004931/Failed+to+install+repo+key
+# the *correct* fix for this would be to have our backups script and
+# its dependencies installed into a virtualenv so it doesn't conflict
+# with system-wide libraries. That's a large change though
+# so for now, as a workaround, we just downgrade urllib3 back to a known safe version
+- name: pin urllib3 back down to a version that doesn't break ansible
+  pip: name={{ item.name }} version={{ item.version }}
+  with_items:
+    - {name: urllib3, version: 1.13.1}
+  when: BACKUPS_PROVIDER == 'gs'
+  tags: ['backups']


### PR DESCRIPTION
The backups script for GCP installs a bunch of python libraries system-wide. One of those as a side-effect now results in a version of `urllib3` getting installed system-wide that then breaks ansible on subsequent deploys:

https://appsembler.atlassian.net/wiki/spaces/ED/pages/390004931/Failed+to+install+repo+key

A proper fix would be to move the whole backups script setup into a virtualenv so we don't get conflicts. But since this is only a problem on Hawthorn (Juniper uses a newer version of Ansible that is OK with upgrading urllib3), the simple workaround for now is to just downgrade urllib3 back to a known safe version at the end of the task.
