### PR TITLE
run node exporter role earlier in playbook

### DIFF
--- a/playbooks/appsemblerPlaybooks/hawthorn_pro.yml
+++ b/playbooks/appsemblerPlaybooks/hawthorn_pro.yml
@@ -52,6 +52,15 @@
     - role: nginx
       nginx_sites: []
       tags: ['nginx_role']
+    - role: "{{ appsembler_roles }}/node_exporter"
+      node_exporter_enabled_collectors:
+        - systemd
+        - supervisord
+        - textfile:
+            directory: "{{ node_exporter_textfile_dir }}"
+        - filesystem:
+            ignored-mount-points: "^/(sys|proc|dev|var|run)($|/)"
+            ignored-fs-types: "^(sys|proc|auto|shm|tmp|ns)fs$"
     - role: "{{ appsembler_roles }}/scriabin"
     - role: "{{ appsembler_roles }}/nxmon"
     - role: "{{ appsembler_roles }}/letsencrypt"
@@ -105,15 +114,6 @@
         - "COMMON_ENVIRONMENT == 'prod'"
       tags: ['appsembler_reporting_role']
     - role: "{{ appsembler_roles }}/google-fluentd"
-    - role: "{{ appsembler_roles }}/node_exporter"
-      node_exporter_enabled_collectors:
-        - systemd
-        - supervisord
-        - textfile:
-            directory: "{{ node_exporter_textfile_dir }}"
-        - filesystem:
-            ignored-mount-points: "^/(sys|proc|dev|var|run)($|/)"
-            ignored-fs-types: "^(sys|proc|auto|shm|tmp|ns)fs$"
     - { role: deploy_info, tags: ['deploy'] }
 
 - name: Install xqueue, notifier and rabbitmq


### PR DESCRIPTION
since `edxapp` writes git info out to the node exporter textfile collector directory (see `edxapp/tasks/git_info.yml`), it needs that directory to exist before it can run. On a first install, the `edxapp` role runs before `node_exporter`, so that breaks.

This moves the node exporter role up earlier in the playbook so it has run and created the directory before any of the other roles that might expect it to already exist.

(this has already been fixed in Tahoe and Juniper, so just backporting to hawthorn)
